### PR TITLE
RHEL 7 support

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -30,7 +30,7 @@ class gitlab::install {
       'redhat': {
         yumrepo { 'gitlab_official':
           descr         => 'Official repository for Gitlab',
-          baseurl       => "https://packages.gitlab.com/gitlab/gitlab-${edition}/el/5/\$basearch",
+          baseurl       => "https://packages.gitlab.com/gitlab/gitlab-${edition}/el/\$releasever/\$basearch",
           enabled       => 1,
           gpgcheck      => 0,
           gpgkey        => 'https://packages.gitlab.com/gpg.key',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,7 +10,17 @@ class gitlab::params {
   $manage_package_repo = true
 
   # service parameters
-  $service_enable = true
+  case $::osfamily {
+    'debian': {
+      $service_enable = true
+    }
+    'redhat': {
+      $service_enable = false
+    }
+    default: {
+      $service_enable = true
+    }
+  }
   $service_ensure = running
   $service_manage = true
   $service_name = 'gitlab-runsvdir'

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -11,17 +11,30 @@ class gitlab::service {
   $service_enable = $::gitlab::service_enable
 
   if $service_manage {
-    # TODO: decide if this makes sense
-    service { $service_name:
-      ensure     => $service_ensure,
-      enable     => $service_enable,
-      provider   => 'upstart',
-      restart    => '/usr/bin/gitlab-ctl restart',
-      start      => '/usr/bin/gitlab-ctl start',
-      stop       => '/usr/bin/gitlab-ctl stop',
-      status     => '/usr/bin/gitlab-ctl status',
-      hasstatus  => true,
-      hasrestart => true,
+    case $::osfamily {
+      'debian': {
+        # TODO: decide if this makes sense
+        service { $service_name:
+          ensure     => $service_ensure,
+          enable     => $service_enable,
+          provider   => 'upstart',
+          restart    => '/usr/bin/gitlab-ctl restart',
+          start      => '/usr/bin/gitlab-ctl start',
+          stop       => '/usr/bin/gitlab-ctl stop',
+          status     => '/usr/bin/gitlab-ctl status',
+          hasstatus  => true,
+          hasrestart => true,
+        }
+      }
+      'redhat': {
+        service { $service_name:
+          ensure     => $service_ensure,
+          enable     => $service_enable,
+        }
+      }
+      default: {
+        fail("OS family ${::osfamily} not supported")
+      }
     }
   }
 


### PR DESCRIPTION
This PR addresses some problems to fix some issues RHEL 7 support.

1. Use `$releasever` instead of the hardcoded `5` in the `baseurl` for the `yumrepo`.
2. Don't force the `upstart` service type if it's a redhat family machine. Let puppet infer that it's `systemd`.
3. Because the chef installer symlinks the systemd service to `/etc/systemd/system/default.target.wants/gitlab-runsvdir.service`, it is not enableable. But it gets started on boot due to it being under `default.target.wants`. The work-around is just to tell puppet not to try and enable the service.

For info, you get the following error in you try to enable the service.
```
# systemctl enable gitlab-runsvdir
Failed to issue method call: No such file or directory
```