### PR TITLE
Remove rails; it's a duplicate of gitlab_rails.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -21,7 +21,6 @@ class gitlab::config {
   $logrotate         = $::gitlab::logrotate
   $nginx             = $::gitlab::nginx
   $postgresql        = $::gitlab::postgresql
-  $rails             = $::gitlab::rails
   $redis             = $::gitlab::redis
   $shell             = $::gitlab::shell
   $sidekiq           = $::gitlab::sidekiq

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -100,10 +100,6 @@
 #   Default: undef
 #   Hash of 'postgresql' config parameters.
 #
-# [*rails*]
-#   Default: undef
-#   Hash of 'gitlab_rails' config parameters.
-#
 # [*redis*]
 #   Default: undef
 #   Hash of 'redis' config parameters.
@@ -174,7 +170,6 @@ class gitlab (
   $logrotate           = undef,
   $nginx               = undef,
   $postgresql          = undef,
-  $rails               = undef,
   $redis               = undef,
   $shell               = undef,
   $sidekiq             = undef,
@@ -214,7 +209,6 @@ class gitlab (
   if $logrotate { validate_hash($logrotate) }
   if $nginx { validate_hash($nginx) }
   if $postgresql { validate_hash($postgresql) }
-  if $rails { validate_hash($rails) }
   if $redis { validate_hash($redis) }
   if $shell { validate_hash($shell) }
   if $sidekiq { validate_hash($sidekiq) }

--- a/templates/gitlab.rb.erb
+++ b/templates/gitlab.rb.erb
@@ -25,13 +25,13 @@ external_url '<%= @external_url %>'
 ## If you want to use a single non-default directory to store git data use:
 git_data_dir "<%= git_data_dir %>"
 <%- end -%>
-<%- if @rails -%>
+<%- if @gitlab_rails -%>
 
 ############################
 # gitlab.yml configuration #
 ############################
 
-<%- @rails.each do |k,v| -%>
+<%- @gitlab_rails.each do |k,v| -%>
 gitlab_rails['<%= k -%>'] = <%= decorate(v) %>
 <%- end end -%>
 <%- if @user -%>


### PR DESCRIPTION
I chose gitlab_rails because it matches the name of the configuration section and because it's what's used in README.md.

This resolves #3.