### PR TITLE
Omnibus service fix and template improvement

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -155,6 +155,12 @@ class gitlab (
   $service_enable      = $::gitlab::params::service_enable,
   $service_ensure      = $::gitlab::params::service_ensure,
   $service_manage      = $::gitlab::params::service_manage,
+  $service_restart     = $::gitlab::params::service_restart,
+  $service_start       = $::gitlab::params::service_start,
+  $service_stop        = $::gitlab::params::service_stop,
+  $service_status      = $::gitlab::params::service_status,
+  $service_hasstatus   = $::gitlab::params::service_hasstatus,
+  $service_hasrestart  = $::gitlab::params::service_hasrestart,
   $service_user        = $::gitlab::params::service_user,
   $service_group       = $::gitlab::params::service_group,
   # gitlab specific

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,6 +21,14 @@ class gitlab::params {
       $service_enable = true
     }
   }
+
+  $service_restart    = '/usr/bin/gitlab-ctl restart'
+  $service_start      = '/usr/bin/gitlab-ctl start'
+  $service_stop       = '/usr/bin/gitlab-ctl stop'
+  $service_status     = '/usr/bin/gitlab-ctl status'
+  $service_hasstatus  = true
+  $service_hasrestart = true
+
   $service_ensure = running
   $service_manage = true
   $service_name = 'gitlab-runsvdir'

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -5,36 +5,16 @@
 #
 class gitlab::service {
 
-  $service_manage = $::gitlab::service_manage
-  $service_name   = $::gitlab::service_name
-  $service_ensure = $::gitlab::service_ensure
-  $service_enable = $::gitlab::service_enable
-
-  if $service_manage {
-    case $::osfamily {
-      'debian': {
-        # TODO: decide if this makes sense
-        service { $service_name:
-          ensure     => $service_ensure,
-          enable     => $service_enable,
-          provider   => 'upstart',
-          restart    => '/usr/bin/gitlab-ctl restart',
-          start      => '/usr/bin/gitlab-ctl start',
-          stop       => '/usr/bin/gitlab-ctl stop',
-          status     => '/usr/bin/gitlab-ctl status',
-          hasstatus  => true,
-          hasrestart => true,
-        }
-      }
-      'redhat': {
-        service { $service_name:
-          ensure     => $service_ensure,
-          enable     => $service_enable,
-        }
-      }
-      default: {
-        fail("OS family ${::osfamily} not supported")
-      }
+  if $::gitlab::service_manage {
+    service { $::gitlab::service_name:
+      ensure     => $::gitlab::service_ensure,
+      enable     => $::gitlab::service_enable,
+      restart    => $::gitlab::service_restart,
+      start      => $::gitlab::service_start,
+      stop       => $::gitlab::service_stop,
+      status     => $::gitlab::service_status,
+      hasstatus  => $::gitlab::service_hasstatus,
+      hasrestart => $::gitlab::service_hasrestart,
     }
   }
 

--- a/templates/gitlab.rb.erb
+++ b/templates/gitlab.rb.erb
@@ -31,8 +31,8 @@ git_data_dir "<%= git_data_dir %>"
 # gitlab.yml configuration #
 ############################
 
-<%- @gitlab_rails.each do |k,v| -%>
-gitlab_rails['<%= k -%>'] = <%= decorate(v) %>
+<%- @gitlab_rails.keys.sort.each do |k| -%>
+gitlab_rails['<%= k -%>'] = <%= decorate(@gitlab_rails[k]) %>
 <%- end end -%>
 <%- if @user -%>
 
@@ -42,8 +42,8 @@ gitlab_rails['<%= k -%>'] = <%= decorate(v) %>
 ## see https://gitlab.com/gitlab-org/omnibus-gitlab/tree/629def0a7a26e7c2326566f0758d4a27857b52a3/README.md#changing-the-name-of-the-git-user-group
 ## Modify default git user.
 
-<%- @user.each do |k,v| -%>
-user['<%= k -%>'] = <%= decorate(v) %>
+<%- @user.keys.sort.each do |k| -%>
+user['<%= k -%>'] = <%= decorate(@user[k]) %>
 <%- end end -%>
 <%- if @unicorn -%>
 
@@ -52,8 +52,8 @@ user['<%= k -%>'] = <%= decorate(v) %>
 ##################
 ## Tweak unicorn settings.
 
-<%- @unicorn.each do |k,v| -%>
-unicorn['<%= k -%>'] = <%= decorate(v) %>
+<%- @unicorn.keys.sort.each do |k| -%>
+unicorn['<%= k -%>'] = <%= decorate(@unicorn[k]) %>
 <%- end end -%>
 <%- if @sidekiq -%>
 
@@ -61,8 +61,8 @@ unicorn['<%= k -%>'] = <%= decorate(v) %>
 # GitLab Sidekiq #
 ##################
 
-<%- @sidekiq.each do |k,v| -%>
-sidekiq['<%= k -%>'] = <%= decorate(v) %>
+<%- @sidekiq.keys.sort.each do |k| -%>
+sidekiq['<%= k -%>'] = <%= decorate(@sidekiq[k]) %>
 <%- end end -%>
 <%- if @shell -%>
 
@@ -70,8 +70,8 @@ sidekiq['<%= k -%>'] = <%= decorate(v) %>
 # gitlab-shell #
 ################
 
-<%- @shell.each do |k,v| -%>
-gitlab_shell['<%= k -%>'] = <%= decorate(v) %>
+<%- @shell.keys.sort.each do |k| -%>
+gitlab_shell['<%= k -%>'] = <%= decorate(@shell[k]) %>
 <%- end end -%>
 <%- if @postgresql -%>
 
@@ -79,8 +79,8 @@ gitlab_shell['<%= k -%>'] = <%= decorate(v) %>
 # GitLab PostgreSQL #
 #####################
 
-<%- @postgresql.each do |k,v| -%>
-postgresql['<%= k -%>'] = <%= decorate(v) %>
+<%- @postgresql.keys.sort.each do |k| -%>
+postgresql['<%= k -%>'] = <%= decorate(@postgresql[k]) %>
 <%- end end -%>
 <%- if @redis -%>
 
@@ -89,8 +89,8 @@ postgresql['<%= k -%>'] = <%= decorate(v) %>
 ################
 ## Can be disabled if you are using your own redis instance.
 
-<%- @redis.each do |k,v| -%>
-redis['<%= k -%>'] = <%= decorate(v) %>
+<%- @redis.keys.sort.each do |k| -%>
+redis['<%= k -%>'] = <%= decorate(@redis[k]) %>
 <%- end end -%>
 <%- if @web_server -%>
 
@@ -100,8 +100,8 @@ redis['<%= k -%>'] = <%= decorate(v) %>
 ## see: https://gitlab.com/gitlab-org/omnibus-gitlab/tree/629def0a7a26e7c2326566f0758d4a27857b52a3/doc/settings/nginx.md#using-a-non-bundled-web-server
 ## When bundled nginx is disabled we need to add the external webserver user to the GitLab webserver group.
 
-<%- @web_server.each do |k,v| -%>
-web_server['<%= k -%>'] = <%= decorate(v) %>
+<%- @web_server.keys.sort.each do |k| -%>
+web_server['<%= k -%>'] = <%= decorate(@web_server[k]) %>
 <%- end end -%>
 <%- if @nginx -%>
 
@@ -110,8 +110,8 @@ web_server['<%= k -%>'] = <%= decorate(v) %>
 ################
 ## see: https://gitlab.com/gitlab-org/omnibus-gitlab/tree/629def0a7a26e7c2326566f0758d4a27857b52a3/doc/settings/nginx.md
 
-<%- @nginx.each do |k,v| -%>
-nginx['<%= k -%>'] = <%= decorate(v) %>
+<%- @nginx.keys.sort.each do |k| -%>
+nginx['<%= k -%>'] = <%= decorate(@nginx[k]) %>
 <%- end end -%>
 <%- if @logging -%>
 
@@ -120,8 +120,8 @@ nginx['<%= k -%>'] = <%= decorate(v) %>
 ##################
 ## see: https://gitlab.com/gitlab-org/omnibus-gitlab/tree/629def0a7a26e7c2326566f0758d4a27857b52a3/README.md#logs
 
-<%- @logging.each do |k,v| -%>
-logging['<%= k -%>'] = <%= decorate(v) %>
+<%- @logging.keys.sort.each do |k| -%>
+logging['<%= k -%>'] = <%= decorate(@logging[k]) %>
 <%- end end -%>
 <%- if @logrotate -%>
 
@@ -131,8 +131,8 @@ logging['<%= k -%>'] = <%= decorate(v) %>
 ## see: https://gitlab.com/gitlab-org/omnibus-gitlab/tree/629def0a7a26e7c2326566f0758d4a27857b52a3/README.md#logrotate
 ## You can disable built in logrotate feature.
 
-<%- @logrotate.each do |k,v| -%>
-logrotate['<%= k -%>'] = <%= decorate(v) %>
+<%- @logrotate.keys.sort.each do |k| -%>
+logrotate['<%= k -%>'] = <%= decorate(@logrotate[k]) %>
 <%- end end -%>
 <%- if @git -%>
 
@@ -143,8 +143,8 @@ logrotate['<%= k -%>'] = <%= decorate(v) %>
 ## For multiple options under one header use array of comma separated values, eg.
 ## { "receive" => ["fsckObjects = true"], "alias" => ["st = status", "co = checkout"] }
 
-<%- @git.each do |k,v| -%>
-omnibus_gitconfig['<%= k -%>'] = <%= decorate(v) %>
+<%- @git.keys.sort.each do |k| -%>
+omnibus_gitconfig['<%= k -%>'] = <%= decorate(@git[k]) %>
 <%- end end -%>
 <%- if @ci_external_url -%>
 
@@ -161,8 +161,8 @@ ci_external_url "<%= ci_external_url %>"
 # application.yml configuration #
 #################################
 
-<%- @gitlab_ci.each do |k,v| -%>
-gitlab_ci['<%= k -%>'] = <%= decorate(v) %>
+<%- @gitlab_ci.keys.sort.each do |k| -%>
+gitlab_ci['<%= k -%>'] = <%= decorate(@gitlab_ci[k]) %>
 <%- end end -%>
 <%- if @ci_unicorn -%>
 
@@ -171,8 +171,8 @@ gitlab_ci['<%= k -%>'] = <%= decorate(v) %>
 #####################
 ## Tweak unicorn settings.
 
-<%- @ci_unicorn.each do |k,v| -%>
-ci_unicorn['<%= k -%>'] = <%= decorate(v) %>
+<%- @ci_unicorn.keys.sort.each do |k| -%>
+ci_unicorn['<%= k -%>'] = <%= decorate(@ci_unicorn[k]) %>
 <%- end end -%>
 <%- if @ci_redis -%>
 
@@ -182,8 +182,8 @@ ci_unicorn['<%= k -%>'] = <%= decorate(v) %>
 ## see https://gitlab.com/gitlab-org/omnibus-gitlab/tree/629def0a7a26e7c2326566f0758d4a27857b52a3/doc/settings/redis.md
 ## You can turn off bundled redis if you want to use your own redis instanance
 
-<%- @ci_redis.each do |k,v| -%>
-ci_redis['<%= k -%>'] = <%= decorate(v) %>
+<%- @ci_redis.keys.sort.each do |k| -%>
+ci_redis['<%= k -%>'] = <%= decorate(@ci_redis[k]) %>
 <%- end end -%>
 <%- if @_real_ci_nginx -%>
 
@@ -193,8 +193,8 @@ ci_redis['<%= k -%>'] = <%= decorate(v) %>
 ## see https://gitlab.com/gitlab-org/omnibus-gitlab/tree/629def0a7a26e7c2326566f0758d4a27857b52a3/doc/settings/nginx.md
 ## You can tell the bundled NGINX that it should not serve up GitLab CI by setting ci_nginx['enable'] to false.
 
-<%- @_real_ci_nginx.each do |k,v| -%>
-ci_nginx['<%= k -%>'] = <%= decorate(v) %>
+<%- @_real_ci_nginx.keys.sort.each do |k| -%>
+ci_nginx['<%= k -%>'] = <%= decorate(@_real_ci_nginx[k]) %>
 <%- end end -%>
 <%- if @high_availability -%>
 
@@ -203,6 +203,6 @@ ci_nginx['<%= k -%>'] = <%= decorate(v) %>
 #####################
 ## see: https://gitlab.com/gitlab-org/omnibus-gitlab/blob/629def0a7a26e7c2326566f0758d4a27857b52a3/README.md#only-start-omnibus-gitlab-services-after-a-given-filesystem-is-mounted
 
-<%- @high_availability.each do |k,v| -%>
-high_availability['<%= k -%>'] = <%= decorate(v) %>
+<%- @high_availability.keys.sort.each do |k| -%>
+high_availability['<%= k -%>'] = <%= decorate(@high_availability[k]) %>
 <%- end end -%>


### PR DESCRIPTION
I was testing this on CentOS 6.6 and was running into issues with the service being managed correctly. Since we are using the omnibus package regardless of os, let's use the gitlab-ctl commands all the time. I also experienced an issue where the gitlab.rb template was changing the order of config lines on subsequent runs which would result in unnecessary restarts of gitlab. I changed the template to sort the keys of the hash first and that alleviated the problem. This is nice in general for a clean and organized config.