### PR TITLE
Fixed issue with using $releasever for RedHat

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -29,9 +29,11 @@ class gitlab::install {
         }
       }
       'redhat': {
+        $releasever = $::os[release][major]
+
         yumrepo { 'gitlab_official':
           descr         => 'Official repository for Gitlab',
-          baseurl       => "https://packages.gitlab.com/gitlab/gitlab-${edition}/el/\$releasever/\$basearch",
+          baseurl       => "https://packages.gitlab.com/gitlab/gitlab-${edition}/el/${releasever}/\$basearch",
           enabled       => 1,
           gpgcheck      => 0,
           gpgkey        => 'https://packages.gitlab.com/gpg.key',

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -30,7 +30,11 @@ class gitlab::install {
         }
       }
       'redhat': {
-        $releasever = $::os[release][major]
+        $releasever = "\$releasever"
+        
+        if is_hash($::os) {
+          $releasever = $::os[release][major]
+        }
 
         yumrepo { 'gitlab_official':
           descr         => 'Official repository for Gitlab',


### PR DESCRIPTION
If using RedHat 6.5, using $releasever in the yum repository fails with the following message

```
Error: Execution of '/usr/bin/yum -d 0 -e 0 -y list gitlab-ce' returned 1: Error: Cannot retrieve repository metadata (repomd.xml) for repository: gitlab_official. Please verify its path and try again
```

Using the `$::os[release][major]` fact fixes this issue, the stringify_facts option must be set to false for this to work.