### PR TITLE
Updated erb template to accomodate for values being hashes

### DIFF
--- a/templates/gitlab.rb.erb
+++ b/templates/gitlab.rb.erb
@@ -9,6 +9,9 @@
   elsif v.is_a?(Array)
     vedit = v.map { |s| "\"#{s}\"" }
     return "[#{vedit.join(',')}]"
+  elsif v.is_a?(Hash)
+    vedit = v.map { |k,s| "\"#{k}\" => \"#{s}\"" }
+    return "{#{vedit.join(',')}}"
   else
     return v
   end


### PR DESCRIPTION
For values such as gitlab_rails['backup_upload_connection'] whereby the value should be a hash, using a string or array is not possible as the decorate function wraps the value in quotes. This change maps the hash into a ruby hash suitable for use.

It also means that these values can be specified within hiera

```yaml
gitlab::gitlab_rails:
  backup_upload_connection:
    provider: 'AWS'
    region: 'eu-west-1'
```