### PR TITLE
Added check for external database

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -53,6 +53,15 @@ class gitlab::config {
       refreshonly => true,
       timeout     => 1800,
     }
+
+    unless $postgresql[enable] {
+      exec { 'gitlab_setup':
+        command     => '/usr/bin/gitlab-rake gitlab:setup',
+        refreshonly => true,
+        timeout     => 1800,
+        require     => Exec['gitlab_reconfigure']
+      }
+    }
   }
 
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -56,10 +56,15 @@ class gitlab::config {
 
     unless $postgresql[enable] {
       exec { 'gitlab_setup':
-        command     => '/usr/bin/gitlab-rake gitlab:setup',
+        command     => 'echo yes | /usr/bin/gitlab-rake gitlab:setup',
         refreshonly => true,
         timeout     => 1800,
-        require     => Exec['gitlab_reconfigure']
+        require     => Exec['gitlab_reconfigure'],
+        unless      => "/bin/grep complete ${git_data_dir}/postgresql.setup"
+      }
+      ->
+      file { "${git_data_dir}/postgresql.setup":
+        content => 'complete'
       }
     }
   }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -57,7 +57,7 @@ class gitlab::config {
     if is_hash($postgresql) {
       unless $postgresql[enable] {
         exec { 'gitlab_setup':
-          command     => 'echo yes | /usr/bin/gitlab-rake gitlab:setup',
+          command     => '/bin/echo yes | /usr/bin/gitlab-rake gitlab:setup',
           refreshonly => true,
           timeout     => 1800,
           require     => Exec['gitlab_reconfigure'],

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -54,17 +54,19 @@ class gitlab::config {
       timeout     => 1800,
     }
 
-    unless $postgresql[enable] {
-      exec { 'gitlab_setup':
-        command     => 'echo yes | /usr/bin/gitlab-rake gitlab:setup',
-        refreshonly => true,
-        timeout     => 1800,
-        require     => Exec['gitlab_reconfigure'],
-        unless      => "/bin/grep complete ${git_data_dir}/postgresql.setup"
-      }
-      ->
-      file { "${git_data_dir}/postgresql.setup":
-        content => 'complete'
+    if is_hash($postgresql) {
+      unless $postgresql[enable] {
+        exec { 'gitlab_setup':
+          command     => 'echo yes | /usr/bin/gitlab-rake gitlab:setup',
+          refreshonly => true,
+          timeout     => 1800,
+          require     => Exec['gitlab_reconfigure'],
+          unless      => "/bin/grep complete ${git_data_dir}/postgresql.setup"
+        }
+        ->
+        file { "${git_data_dir}/postgresql.setup":
+          content => 'complete'
+        }
       }
     }
   }


### PR DESCRIPTION
If using an external database, an additional exec step is needed as outlined in the gitlab documentation:

https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/doc/settings/database.md