### PR TITLE
Add retries to gitlab-ctl reconfigure

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -72,6 +72,8 @@ class gitlab::config {
       command     => '/usr/bin/gitlab-ctl reconfigure',
       refreshonly => true,
       timeout     => 1800,
+      logoutput   => true,
+      tries       => 5,
     }
 
     if is_hash($postgresql) {


### PR DESCRIPTION
For some reason the reconfigure command will fail on my first puppet run but then resolve itself if the command is run manually.  Adding additional tries during the puppet run resolves the issue.

Here's a snippet of my `puppet agent -t --debug` run.  You can see if needs the second try but I'm not positive as to why

```
Info: /Stage[main]/Gitlab::Config/File[/etc/gitlab/gitlab.rb]: Filebucketed /etc/gitlab/gitlab.rb to main with sum 81d8999f68d05ba8b171595c87cd1028
Notice: /Stage[main]/Gitlab::Config/File[/etc/gitlab/gitlab.rb]/content: content changed '{md5}81d8999f68d05ba8b171595c87cd1028' to '{md5}ae1263a13cf4003ac48f0ee8d1616849'
Info: /Stage[main]/Gitlab::Config/File[/etc/gitlab/gitlab.rb]: Scheduling refresh of Exec[gitlab_reconfigure]
Debug: /Stage[main]/Gitlab::Config/File[/etc/gitlab/gitlab.rb]: The container Class[Gitlab::Config] will propagate my refresh event
Debug: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: Exec try 1/5
Debug: Exec[gitlab_reconfigure](provider=posix): Executing '/usr/bin/gitlab-ctl reconfigure'
Debug: Executing: '/usr/bin/gitlab-ctl reconfigure'
Debug: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: Exec try 2/5
Debug: Exec[gitlab_reconfigure](provider=posix): Executing '/usr/bin/gitlab-ctl reconfigure'
Debug: Executing: '/usr/bin/gitlab-ctl reconfigure'
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:13:58+00:00] INFO: Started chef-zero at chefzero://localhost:8889 with repository at /opt/gitlab/embedded
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns:   One version per cookbook
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns:
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:13:58+00:00] INFO: Forking chef instance to converge...
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:13:58+00:00] INFO: *** Chef 12.4.0.rc.2 ***
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:13:58+00:00] INFO: Chef-client pid: 5407
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:13:59+00:00] INFO: HTTP Request Returned 404 Not Found: Object not found: chefzero://localhost:8889/nodes/gitlab-server
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:13:59+00:00] INFO: Setting the run_list to ["recipe[gitlab]"] from CLI options
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:13:59+00:00] INFO: Run List is [recipe[gitlab]]
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:13:59+00:00] INFO: Run List expands to [gitlab]
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:13:59+00:00] INFO: Starting Chef Run for gitlab-server
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:13:59+00:00] INFO: Running start handlers
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:13:59+00:00] INFO: Start handlers complete.
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:13:59+00:00] INFO: HTTP Request Returned 404 Not Found: Object not found:
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:13:59+00:00] WARN: Cookbook 'local-mode-cache' is empty or entirely chefignored at /opt/gitlab/embedded/cookbooks/local-mode-cache
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:13:59+00:00] WARN: Cookbook 'local-mode-cache' is empty or entirely chefignored at /opt/gitlab/embedded/cookbooks/local-mode-cache
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:13:59+00:00] WARN: Cookbook 'local-mode-cache' is empty or entirely chefignored at /opt/gitlab/embedded/cookbooks/local-mode-cache
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:13:59+00:00] WARN: Cookbook 'local-mode-cache' is empty or entirely chefignored at /opt/gitlab/embedded/cookbooks/local-mode-cache
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:13:59+00:00] WARN: Cookbook 'local-mode-cache' is empty or entirely chefignored at /opt/gitlab/embedded/cookbooks/local-mode-cache
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:13:59+00:00] WARN: Cookbook 'local-mode-cache' is empty or entirely chefignored at /opt/gitlab/embedded/cookbooks/local-mode-cache
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:13:59+00:00] WARN: Cookbook 'local-mode-cache' is empty or entirely chefignored at /opt/gitlab/embedded/cookbooks/local-mode-cache
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:13:59+00:00] WARN: Cookbook 'local-mode-cache' is empty or entirely chefignored at /opt/gitlab/embedded/cookbooks/local-mode-cache
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:13:59+00:00] WARN: Cookbook 'local-mode-cache' is empty or entirely chefignored at /opt/gitlab/embedded/cookbooks/local-mode-cache
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:13:59+00:00] WARN: Cookbook 'local-mode-cache' is empty or entirely chefignored at /opt/gitlab/embedded/cookbooks/local-mode-cache
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:13:59+00:00] WARN: Cookbook 'local-mode-cache' is empty or entirely chefignored at /opt/gitlab/embedded/cookbooks/local-mode-cache
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:13:59+00:00] WARN: Cookbook 'local-mode-cache' is empty or entirely chefignored at /opt/gitlab/embedded/cookbooks/local-mode-cache
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:13:59+00:00] WARN: Cookbook 'local-mode-cache' is empty or entirely chefignored at /opt/gitlab/embedded/cookbooks/local-mode-cache
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:13:59+00:00] WARN: Cookbook 'local-mode-cache' is empty or entirely chefignored at /opt/gitlab/embedded/cookbooks/local-mode-cache
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:13:59+00:00] WARN: Cookbook 'local-mode-cache' is empty or entirely chefignored at /opt/gitlab/embedded/cookbooks/local-mode-cache
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:13:59+00:00] WARN: Cookbook 'local-mode-cache' is empty or entirely chefignored at /opt/gitlab/embedded/cookbooks/local-mode-cache
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:13:59+00:00] WARN: Cookbook 'local-mode-cache' is empty or entirely chefignored at /opt/gitlab/embedded/cookbooks/local-mode-cache
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:13:59+00:00] WARN: Cookbook 'local-mode-cache' is empty or entirely chefignored at /opt/gitlab/embedded/cookbooks/local-mode-cache
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:13:59+00:00] INFO: Loading cookbooks [gitlab@0.0.1, runit@0.14.2, package@0.0.0]
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:13:59+00:00] WARN: Cloning resource attributes for directory[/var/opt/gitlab] from prior resource (CHEF-3694)
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:13:59+00:00] WARN: Previous directory[/var/opt/gitlab]: /opt/gitlab/embedded/cookbooks/cache/cookbooks/gitlab/recipes/default.rb:43:in `from_file'
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:13:59+00:00] WARN: Current  directory[/var/opt/gitlab]: /opt/gitlab/embedded/cookbooks/cache/cookbooks/gitlab/recipes/users.rb:23:in `from_file'
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:13:59+00:00] WARN: Cloning resource attributes for cron[gitlab-ci schedule builds] from prior resource (CHEF-3694)
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:13:59+00:00] WARN: Previous cron[gitlab-ci schedule builds]: /opt/gitlab/embedded/cookbooks/cache/cookbooks/gitlab/recipes/cron.rb:19:in `from_file'
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:13:59+00:00] WARN: Current  cron[gitlab-ci schedule builds]: /opt/gitlab/embedded/cookbooks/cache/cookbooks/gitlab/recipes/cron.rb:24:in `from_file'
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: init (upstart 0.6.5)
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:13:59+00:00] WARN: Selected upstart because /sbin/init --version is showing upstart.
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:00+00:00] WARN: Cloning resource attributes for directory[/var/opt/gitlab/gitlab-rails/etc] from prior resource (CHEF-3694)
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:00+00:00] WARN: Previous directory[/var/opt/gitlab/gitlab-rails/etc]: /opt/gitlab/embedded/cookbooks/cache/cookbooks/gitlab/recipes/gitlab-rails.rb:41:in `block in from_file'
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:00+00:00] WARN: Current  directory[/var/opt/gitlab/gitlab-rails/etc]: /opt/gitlab/embedded/cookbooks/cache/cookbooks/gitlab/definitions/unicorn_config.rb:21:in `block in from_file'
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:00+00:00] WARN: Cloning resource attributes for service[unicorn] from prior resource (CHEF-3694)
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:00+00:00] WARN: Previous service[unicorn]: /opt/gitlab/embedded/cookbooks/cache/cookbooks/gitlab/recipes/default.rb:88:in `block in from_file'
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:00+00:00] WARN: Current  service[unicorn]: /opt/gitlab/embedded/cookbooks/cache/cookbooks/runit/definitions/runit_service.rb:191:in `block in from_file'
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:00+00:00] WARN: Cloning resource attributes for execute[sysctl] from prior resource (CHEF-3694)
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:00+00:00] WARN: Previous execute[sysctl]: /opt/gitlab/embedded/cookbooks/cache/cookbooks/gitlab/recipes/postgresql.rb:84:in `from_file'
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:00+00:00] WARN: Current  execute[sysctl]: /opt/gitlab/embedded/cookbooks/cache/cookbooks/gitlab/recipes/unicorn.rb:39:in `from_file'
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:00+00:00] WARN: Cloning resource attributes for service[sidekiq] from prior resource (CHEF-3694)
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:00+00:00] WARN: Previous service[sidekiq]: /opt/gitlab/embedded/cookbooks/cache/cookbooks/gitlab/recipes/default.rb:88:in `block in from_file'
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:00+00:00] WARN: Current  service[sidekiq]: /opt/gitlab/embedded/cookbooks/cache/cookbooks/runit/definitions/runit_service.rb:191:in `block in from_file'
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:00+00:00] INFO: execute[chown -R root:root /opt/gitlab/embedded/service/gitlab-rails/public] ran successfully
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:00+00:00] INFO: execute[initctl status gitlab-runsvdir] ran successfully
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:00+00:00] INFO: execute[/opt/gitlab/bin/gitlab-ctl start redis] ran successfully
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:01+00:00] INFO: execute[/opt/gitlab/bin/gitlab-ctl start postgresql] ran successfully
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:01+00:00] INFO: execute[/opt/gitlab/bin/gitlab-ctl start unicorn] ran successfully
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:01+00:00] INFO: directory[/var/log/gitlab/sidekiq] created directory /var/log/gitlab/sidekiq
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:01+00:00] INFO: directory[/var/log/gitlab/sidekiq] owner changed to 496
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:01+00:00] INFO: directory[/var/log/gitlab/sidekiq] mode changed to 700
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:01+00:00] INFO: directory[/opt/gitlab/sv/sidekiq] created directory /opt/gitlab/sv/sidekiq
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:01+00:00] INFO: directory[/opt/gitlab/sv/sidekiq] owner changed to 0
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:01+00:00] INFO: directory[/opt/gitlab/sv/sidekiq] group changed to 0
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:01+00:00] INFO: directory[/opt/gitlab/sv/sidekiq] mode changed to 755
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:01+00:00] INFO: directory[/opt/gitlab/sv/sidekiq/log] created directory /opt/gitlab/sv/sidekiq/log
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:01+00:00] INFO: directory[/opt/gitlab/sv/sidekiq/log] owner changed to 0
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:01+00:00] INFO: directory[/opt/gitlab/sv/sidekiq/log] group changed to 0
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:01+00:00] INFO: directory[/opt/gitlab/sv/sidekiq/log] mode changed to 755
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:01+00:00] INFO: directory[/opt/gitlab/sv/sidekiq/log/main] created directory /opt/gitlab/sv/sidekiq/log/main
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:01+00:00] INFO: directory[/opt/gitlab/sv/sidekiq/log/main] owner changed to 0
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:01+00:00] INFO: directory[/opt/gitlab/sv/sidekiq/log/main] group changed to 0
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:01+00:00] INFO: directory[/opt/gitlab/sv/sidekiq/log/main] mode changed to 755
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:01+00:00] INFO: template[/opt/gitlab/sv/sidekiq/run] created file /opt/gitlab/sv/sidekiq/run
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:01+00:00] INFO: template[/opt/gitlab/sv/sidekiq/run] updated file contents /opt/gitlab/sv/sidekiq/run
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:01+00:00] INFO: template[/opt/gitlab/sv/sidekiq/run] owner changed to 0
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:01+00:00] INFO: template[/opt/gitlab/sv/sidekiq/run] group changed to 0
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:01+00:00] INFO: template[/opt/gitlab/sv/sidekiq/run] mode changed to 755
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:01+00:00] INFO: template[/opt/gitlab/sv/sidekiq/log/run] created file /opt/gitlab/sv/sidekiq/log/run
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:01+00:00] INFO: template[/opt/gitlab/sv/sidekiq/log/run] updated file contents /opt/gitlab/sv/sidekiq/log/run
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:01+00:00] INFO: template[/opt/gitlab/sv/sidekiq/log/run] owner changed to 0
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:01+00:00] INFO: template[/opt/gitlab/sv/sidekiq/log/run] group changed to 0
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:01+00:00] INFO: template[/opt/gitlab/sv/sidekiq/log/run] mode changed to 755
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:01+00:00] INFO: template[/var/log/gitlab/sidekiq/config] created file /var/log/gitlab/sidekiq/config
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:01+00:00] INFO: template[/var/log/gitlab/sidekiq/config] updated file contents /var/log/gitlab/sidekiq/config
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:01+00:00] INFO: template[/var/log/gitlab/sidekiq/config] owner changed to 0
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:01+00:00] INFO: template[/var/log/gitlab/sidekiq/config] group changed to 0
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:01+00:00] INFO: link[/opt/gitlab/init/sidekiq] created
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:01+00:00] INFO: link[/opt/gitlab/service/sidekiq] created
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: ruby_block[supervise_sidekiq_sleep] called
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: execute[/opt/gitlab/bin/gitlab-ctl start sidekiq] ran successfully
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: directory[/var/opt/gitlab/nginx] created directory /var/opt/gitlab/nginx
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: directory[/var/opt/gitlab/nginx] owner changed to 0
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: directory[/var/opt/gitlab/nginx] group changed to 498
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: directory[/var/opt/gitlab/nginx] mode changed to 750
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: directory[/var/opt/gitlab/nginx/conf] created directory /var/opt/gitlab/nginx/conf
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: directory[/var/opt/gitlab/nginx/conf] owner changed to 0
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: directory[/var/opt/gitlab/nginx/conf] group changed to 498
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: directory[/var/opt/gitlab/nginx/conf] mode changed to 750
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: directory[/var/log/gitlab/nginx] created directory /var/log/gitlab/nginx
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: directory[/var/log/gitlab/nginx] owner changed to 0
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: directory[/var/log/gitlab/nginx] group changed to 498
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: directory[/var/log/gitlab/nginx] mode changed to 750
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: link[/var/opt/gitlab/nginx/logs] created
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: template[/var/opt/gitlab/nginx/conf/gitlab-http.conf] created file /var/opt/gitlab/nginx/conf/gitlab-http.conf
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: template[/var/opt/gitlab/nginx/conf/gitlab-http.conf] updated file contents /var/opt/gitlab/nginx/conf/gitlab-http.conf
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: template[/var/opt/gitlab/nginx/conf/gitlab-http.conf] owner changed to 0
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: template[/var/opt/gitlab/nginx/conf/gitlab-http.conf] group changed to 0
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: template[/var/opt/gitlab/nginx/conf/gitlab-http.conf] mode changed to 644
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: template[/var/opt/gitlab/nginx/conf/nginx.conf] created file /var/opt/gitlab/nginx/conf/nginx.conf
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: template[/var/opt/gitlab/nginx/conf/nginx.conf] updated file contents /var/opt/gitlab/nginx/conf/nginx.conf
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: template[/var/opt/gitlab/nginx/conf/nginx.conf] owner changed to 0
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: template[/var/opt/gitlab/nginx/conf/nginx.conf] group changed to 0
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: template[/var/opt/gitlab/nginx/conf/nginx.conf] mode changed to 644
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: directory[/opt/gitlab/sv/nginx] created directory /opt/gitlab/sv/nginx
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: directory[/opt/gitlab/sv/nginx] owner changed to 0
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: directory[/opt/gitlab/sv/nginx] group changed to 0
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: directory[/opt/gitlab/sv/nginx] mode changed to 755
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: directory[/opt/gitlab/sv/nginx/log] created directory /opt/gitlab/sv/nginx/log
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: directory[/opt/gitlab/sv/nginx/log] owner changed to 0
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: directory[/opt/gitlab/sv/nginx/log] group changed to 0
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: directory[/opt/gitlab/sv/nginx/log] mode changed to 755
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: directory[/opt/gitlab/sv/nginx/log/main] created directory /opt/gitlab/sv/nginx/log/main
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: directory[/opt/gitlab/sv/nginx/log/main] owner changed to 0
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: directory[/opt/gitlab/sv/nginx/log/main] group changed to 0
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: directory[/opt/gitlab/sv/nginx/log/main] mode changed to 755
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: template[/opt/gitlab/sv/nginx/run] created file /opt/gitlab/sv/nginx/run
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: template[/opt/gitlab/sv/nginx/run] updated file contents /opt/gitlab/sv/nginx/run
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: template[/opt/gitlab/sv/nginx/run] owner changed to 0
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: template[/opt/gitlab/sv/nginx/run] group changed to 0
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: template[/opt/gitlab/sv/nginx/run] mode changed to 755
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: template[/opt/gitlab/sv/nginx/log/run] created file /opt/gitlab/sv/nginx/log/run
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: template[/opt/gitlab/sv/nginx/log/run] updated file contents /opt/gitlab/sv/nginx/log/run
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: template[/opt/gitlab/sv/nginx/log/run] owner changed to 0
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: template[/opt/gitlab/sv/nginx/log/run] group changed to 0
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: template[/opt/gitlab/sv/nginx/log/run] mode changed to 755
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: template[/var/log/gitlab/nginx/config] created file /var/log/gitlab/nginx/config
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: template[/var/log/gitlab/nginx/config] updated file contents /var/log/gitlab/nginx/config
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: template[/var/log/gitlab/nginx/config] owner changed to 0
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: template[/var/log/gitlab/nginx/config] group changed to 0
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: link[/opt/gitlab/init/nginx] created
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:03+00:00] INFO: link[/opt/gitlab/service/nginx] created
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:04+00:00] INFO: ruby_block[supervise_nginx_sleep] called
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:04+00:00] INFO: execute[/opt/gitlab/bin/gitlab-ctl start nginx] ran successfully
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:04+00:00] INFO: directory[/var/opt/gitlab/logrotate] created directory /var/opt/gitlab/logrotate
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:04+00:00] INFO: directory[/var/opt/gitlab/logrotate] mode changed to 700
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:04+00:00] INFO: directory[/var/opt/gitlab/logrotate/logrotate.d] created directory /var/opt/gitlab/logrotate/logrotate.d
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:04+00:00] INFO: directory[/var/opt/gitlab/logrotate/logrotate.d] mode changed to 700
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:04+00:00] INFO: directory[/var/log/gitlab/logrotate] created directory /var/log/gitlab/logrotate
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:04+00:00] INFO: directory[/var/log/gitlab/logrotate] mode changed to 700
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:04+00:00] INFO: template[/var/opt/gitlab/logrotate/logrotate.conf] created file /var/opt/gitlab/logrotate/logrotate.conf
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:04+00:00] INFO: template[/var/opt/gitlab/logrotate/logrotate.conf] updated file contents /var/opt/gitlab/logrotate/logrotate.conf
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:04+00:00] INFO: template[/var/opt/gitlab/logrotate/logrotate.conf] mode changed to 644
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:04+00:00] INFO: template[/var/opt/gitlab/logrotate/logrotate.d/nginx] created file /var/opt/gitlab/logrotate/logrotate.d/nginx
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:04+00:00] INFO: template[/var/opt/gitlab/logrotate/logrotate.d/nginx] updated file contents /var/opt/gitlab/logrotate/logrotate.d/nginx
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:04+00:00] INFO: template[/var/opt/gitlab/logrotate/logrotate.d/unicorn] created file /var/opt/gitlab/logrotate/logrotate.d/unicorn
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:04+00:00] INFO: template[/var/opt/gitlab/logrotate/logrotate.d/unicorn] updated file contents /var/opt/gitlab/logrotate/logrotate.d/unicorn
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:04+00:00] INFO: template[/var/opt/gitlab/logrotate/logrotate.d/gitlab-rails] created file /var/opt/gitlab/logrotate/logrotate.d/gitlab-rails
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:04+00:00] INFO: template[/var/opt/gitlab/logrotate/logrotate.d/gitlab-rails] updated file contents /var/opt/gitlab/logrotate/logrotate.d/gitlab-rails
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:04+00:00] INFO: template[/var/opt/gitlab/logrotate/logrotate.d/gitlab-shell] created file /var/opt/gitlab/logrotate/logrotate.d/gitlab-shell
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:04+00:00] INFO: template[/var/opt/gitlab/logrotate/logrotate.d/gitlab-shell] updated file contents /var/opt/gitlab/logrotate/logrotate.d/gitlab-shell
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:04+00:00] INFO: template[/var/opt/gitlab/logrotate/logrotate.d/gitlab-ci] created file /var/opt/gitlab/logrotate/logrotate.d/gitlab-ci
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:04+00:00] INFO: template[/var/opt/gitlab/logrotate/logrotate.d/gitlab-ci] updated file contents /var/opt/gitlab/logrotate/logrotate.d/gitlab-ci
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:04+00:00] INFO: directory[/opt/gitlab/sv/logrotate] created directory /opt/gitlab/sv/logrotate
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:04+00:00] INFO: directory[/opt/gitlab/sv/logrotate] owner changed to 0
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:04+00:00] INFO: directory[/opt/gitlab/sv/logrotate] group changed to 0
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:04+00:00] INFO: directory[/opt/gitlab/sv/logrotate] mode changed to 755
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:04+00:00] INFO: directory[/opt/gitlab/sv/logrotate/log] created directory /opt/gitlab/sv/logrotate/log
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:04+00:00] INFO: directory[/opt/gitlab/sv/logrotate/log] owner changed to 0
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:04+00:00] INFO: directory[/opt/gitlab/sv/logrotate/log] group changed to 0
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:04+00:00] INFO: directory[/opt/gitlab/sv/logrotate/log] mode changed to 755
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:04+00:00] INFO: directory[/opt/gitlab/sv/logrotate/log/main] created directory /opt/gitlab/sv/logrotate/log/main
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:04+00:00] INFO: directory[/opt/gitlab/sv/logrotate/log/main] owner changed to 0
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:04+00:00] INFO: directory[/opt/gitlab/sv/logrotate/log/main] group changed to 0
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:04+00:00] INFO: directory[/opt/gitlab/sv/logrotate/log/main] mode changed to 755
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:04+00:00] INFO: template[/opt/gitlab/sv/logrotate/run] created file /opt/gitlab/sv/logrotate/run
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:04+00:00] INFO: template[/opt/gitlab/sv/logrotate/run] updated file contents /opt/gitlab/sv/logrotate/run
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:04+00:00] INFO: template[/opt/gitlab/sv/logrotate/run] owner changed to 0
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:04+00:00] INFO: template[/opt/gitlab/sv/logrotate/run] group changed to 0
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:04+00:00] INFO: template[/opt/gitlab/sv/logrotate/run] mode changed to 755
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:04+00:00] INFO: template[/opt/gitlab/sv/logrotate/log/run] created file /opt/gitlab/sv/logrotate/log/run
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:04+00:00] INFO: template[/opt/gitlab/sv/logrotate/log/run] updated file contents /opt/gitlab/sv/logrotate/log/run
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:04+00:00] INFO: template[/opt/gitlab/sv/logrotate/log/run] owner changed to 0
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:04+00:00] INFO: template[/opt/gitlab/sv/logrotate/log/run] group changed to 0
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:04+00:00] INFO: template[/opt/gitlab/sv/logrotate/log/run] mode changed to 755
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:04+00:00] INFO: template[/var/log/gitlab/logrotate/config] created file /var/log/gitlab/logrotate/config
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:04+00:00] INFO: template[/var/log/gitlab/logrotate/config] updated file contents /var/log/gitlab/logrotate/config
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:04+00:00] INFO: template[/var/log/gitlab/logrotate/config] owner changed to 0
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:04+00:00] INFO: template[/var/log/gitlab/logrotate/config] group changed to 0
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:04+00:00] INFO: link[/opt/gitlab/init/logrotate] created
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:04+00:00] INFO: link[/opt/gitlab/service/logrotate] created
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:05+00:00] INFO: ruby_block[supervise_logrotate_sleep] called
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:06+00:00] INFO: execute[/opt/gitlab/bin/gitlab-ctl start logrotate] ran successfully
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:06+00:00] INFO: file[/var/opt/gitlab/bootstrapped] created file /var/opt/gitlab/bootstrapped
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:06+00:00] INFO: file[/var/opt/gitlab/bootstrapped] updated file contents /var/opt/gitlab/bootstrapped
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:06+00:00] INFO: file[/var/opt/gitlab/bootstrapped] owner changed to 0
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:06+00:00] INFO: file[/var/opt/gitlab/bootstrapped] group changed to 0
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:06+00:00] INFO: file[/var/opt/gitlab/bootstrapped] mode changed to 600
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:06+00:00] INFO: template[/var/log/gitlab/sidekiq/config] sending create action to ruby_block[reload sidekiq svlogd configuration] (delayed)
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:06+00:00] INFO: ruby_block[reload sidekiq svlogd configuration] called
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:06+00:00] INFO: template[/var/log/gitlab/nginx/config] sending create action to ruby_block[reload nginx svlogd configuration] (delayed)
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:06+00:00] INFO: ruby_block[reload nginx svlogd configuration] called
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:06+00:00] INFO: template[/var/log/gitlab/logrotate/config] sending create action to ruby_block[reload logrotate svlogd configuration] (delayed)
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:06+00:00] INFO: ruby_block[reload logrotate svlogd configuration] called
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:06+00:00] INFO: Chef Run complete in 6.822433699 seconds
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:06+00:00] INFO: Running report handlers
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: [2015-08-13T18:14:06+00:00] INFO: Report handlers complete
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: gitlab Reconfigured!
Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]: Triggered 'refresh' from 1 events
Debug: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]: The container Class[Gitlab::Config] will propagate my refresh event
```