### PR TITLE
Added the sym-link to the GitLab service executable in the /etc/init.d/.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,6 +20,12 @@
 #   Default: true
 #   Run the system service on boot.
 #
+# [*service_exec*]
+#   Default: '/usr/bin/gitlab-ctl'
+#   The service executable path.
+#   Provide this variable value only if the service executable path
+#   would be a subject of change in future GitLab versions for any reason.
+#
 # [*service_ensure*]
 #   Default: running
 #   Should Puppet start the service?
@@ -191,6 +197,7 @@ class gitlab (
   $service_hasstatus   = $::gitlab::params::service_hasstatus,
   $service_manage      = $::gitlab::params::service_manage,
   $service_name        = $::gitlab::params::service_name,
+  $service_exec        = $::gitlab::params::service_exec,
   $service_restart     = $::gitlab::params::service_restart,
   $service_start       = $::gitlab::params::service_start,
   $service_status      = $::gitlab::params::service_status,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,10 +22,11 @@ class gitlab::params {
     }
   }
 
-  $service_restart = '/usr/bin/gitlab-ctl restart'
-  $service_start = '/usr/bin/gitlab-ctl start'
-  $service_stop = '/usr/bin/gitlab-ctl stop'
-  $service_status = '/usr/bin/gitlab-ctl status'
+  $service_exec = '/usr/bin/gitlab-ctl'
+  $service_restart = "$service_exec restart"
+  $service_start = "$service_exec start"
+  $service_stop = "$service_exec stop"
+  $service_status = "$service_exec status"
   $service_hasstatus = true
   $service_hasrestart = true
 

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -4,8 +4,11 @@
 # It ensure the service is running.
 #
 class gitlab::service {
-
   if $::gitlab::service_manage {
+    file { "/etc/init.d/$::gitlab::service_name":
+      ensure => 'link',
+      target => $::gitlab::service_exec,
+    } ->
     service { $::gitlab::service_name:
       ensure     => $::gitlab::service_ensure,
       enable     => $::gitlab::service_enable,


### PR DESCRIPTION
The proposed fix gets a rid of the following error, while provisioning on the Debian-7 VM:

```bash
==> gitlab: Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]/returns: gitlab Reconfigured!
==> gitlab: Notice: /Stage[main]/Gitlab::Config/Exec[gitlab_reconfigure]: Triggered 'refresh' from 1 events
==> gitlab: Error: Execution of '/usr/sbin/update-rc.d gitlab defaults' returned 1: update-rc.d: error: unable to read /etc/init.d/gitlab
==> gitlab: update-rc.d: using dependency based boot sequencing
==> gitlab: Error: /Stage[main]/Gitlab::Service/Service[gitlab]/enable: change from false to true failed: Execution of '/usr/sbin/update-rc.d gitlab defaults' returned 1: update-rc.d: error: unable to read /etc/init.d/gitlab
==> gitlab: update-rc.d: using dependency based boot sequencing
```