### PR TITLE
Fix issues with deprecated values in apt::source

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,6 +3,6 @@ fixtures:
     stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
     apt:
       repo: "https://github.com/puppetlabs/puppetlabs-apt.git"
-      ref: "1.8.0"
+      ref: "2.0.0"
   symlinks:
     gitlab: "#{source_dir}"

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -13,17 +13,22 @@ class gitlab::install {
   if $manage_package_repo {
     case $::osfamily {
       'debian': {
+        include apt
         Exec['apt_update'] -> Package[$package_name]
         $_lower_os = downcase($::operatingsystem)
         apt::source { 'gitlab_official':
-          comment     => 'Official repository for Gitlab',
-          location    => "https://packages.gitlab.com/gitlab/gitlab-${edition}/${_lower_os}/",
-          release     => $::lsbdistcodename,
-          repos       => 'main',
-          key         => '1A4C919DB987D435939638B914219A96E15E78F4',
-          key_source  => 'https://packages.gitlab.com/gpg.key',
-          include_src => true,
-          include_deb => true,
+          comment  => 'Official repository for Gitlab',
+          location => "https://packages.gitlab.com/gitlab/gitlab-${edition}/${_lower_os}/",
+          release  => $::lsbdistcodename,
+          repos    => 'main',
+          key      => {
+            id     => '1A4C919DB987D435939638B914219A96E15E78F4',
+            source => 'https://packages.gitlab.com/gpg.key',
+          },
+          include  => {
+            src    => true,
+            deb    => true,
+          },
         } ->
         package { $package_name:
           ensure => $package_ensure,

--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">=1.8.0 <3.0.0"
+      "version_requirement": ">=2.0.0 <3.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Fix issues with deprecated values

```
Warning: Scope(Apt::Source[gitlab_official]): $key_source is deprecated and will be removed in the next major release, please use $key => { 'source' => https://packages.gitlab.com/gpg.key } instead.
Warning: Scope(Apt::Source[knot_official]): $include_src is deprecated and will be removed in the next major release, please use $include => { 'src' => true } instead
Warning: Scope(Apt::Source[knot_official]): $include_deb is deprecated and will be removed in the next major release, please use $include => { 'deb' => true } instead
```