### PR TITLE
allow disabling of omnibus user management

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -20,6 +20,7 @@ class gitlab::config {
   $high_availability       = $::gitlab::high_availability
   $logging                 = $::gitlab::logging
   $logrotate               = $::gitlab::logrotate
+  $manage_accounts         = $::gitlab::manage_accounts
   $mattermost              = $::gitlab::mattermost
   $mattermost_external_url = $::gitlab::mattermost_external_url
   $mattermost_nginx        = $::gitlab::mattermost_nginx

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -104,6 +104,10 @@
 #   Default: undef
 #   Hash of 'logrotate' config parameters.
 #
+# [*manage_accounts*]
+#   Default: undef
+#   Hash of 'manage_accounts' config parameters.
+#
 # [*mattermost_external_url*]
 #   Default: undef
 #   External URL of Mattermost.
@@ -213,6 +217,7 @@ class gitlab (
   $high_availability       = undef,
   $logging                 = undef,
   $logrotate               = undef,
+  $manage_accounts         = undef,
   $mattermost              = undef,
   $mattermost_external_url = undef,
   $mattermost_nginx        = undef,
@@ -266,6 +271,7 @@ class gitlab (
   if $user { validate_hash($user) }
   if $web_server { validate_hash($web_server) }
   if $high_availability { validate_hash($high_availability) }
+  if $manage_accounts { validate_hash($manage_accounts) }
 
   class { '::gitlab::install': } ->
   class { '::gitlab::config': } ~>

--- a/templates/gitlab.rb.erb
+++ b/templates/gitlab.rb.erb
@@ -250,3 +250,13 @@ mattermost['<%= k -%>'] = <%= decorate(@mattermost[k]) %>
 <%- @mattermost_nginx.keys.sort.each do |k| -%>
 mattermost_nginx['<%= k -%>'] = <%= decorate(@mattermost_nginx[k]) %>
 <%- end end -%>
+<%- if @manage_accounts -%>
+
+###################
+# Manage Accounts #
+###################
+## see: https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/doc/settings/configuration.md#disable-user-and-group-account-management
+
+<%- @manage_accounts.keys.sort.each do |k| -%>
+manage_accounts['<%= k -%>'] = <%= decorate(@manage_accounts[k]) %>
+<%- end end -%>


### PR DESCRIPTION
add ability to change manage_accounts hash to disable omnibus account management
tested on centos 7