### PR TITLE
Gitlab CI Runner

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,5 +4,8 @@ fixtures:
     apt:
       repo: "https://github.com/puppetlabs/puppetlabs-apt.git"
       ref: "2.2.0"
+    docker:
+      repo: "https://github.com/garethr/garethr-docker.git"
+      ref: "4.1.1"
   symlinks:
     gitlab: "#{source_dir}"

--- a/README.md
+++ b/README.md
@@ -161,11 +161,40 @@ gitlab::gitlab_rails:
       user_filter: ''
 ```
 
+### Gitlab CI Runner Config
+
+Here is an example how to configure Gitlab CI runners using Hiera:
+
+To use the Gitlab CI runners it is required to have the [garethr/docker](https://forge.puppetlabs.com/garethr/docker) module.
+
+$manage_docker can be set to false if docker is managed externaly.
+
+```
+classes:
+  - gitlab::cirunner
+
+gitlab_ci_runners:
+  test_runner1:{}
+  test_runner2:{}
+  test_runner3:
+    url: "https://git.alternative.org/ci"
+    registration-token: "abcdef1234567890"
+
+gitlab_ci_runners_defaults:
+  url: "https://git.example.com/ci"
+  registration-token: "1234567890abcdef"
+  executor: "docker"
+  docker-image: "ubuntu:trusty"
+
 ## Limitations
 
 The supported operating systems by Gitlab Omnibus are to be found on the official [download page](https://about.gitlab.com/downloads/).
 At the moment the module is not yet tested under RPM based operating systems. But in theory it should work
 as all the preparations are there.
+
+### Gitlab CI Runner Limitations
+
+The Gitlab CI runner installation is at the moment only tested on Ubuntu 14.04.
 
 ## Development
 

--- a/manifests/cirunner.pp
+++ b/manifests/cirunner.pp
@@ -1,0 +1,85 @@
+# == Class: gitlab::cirunner
+#
+# This module installs and configures Gitlab CI Runners.
+#
+# === Parameters
+#
+# [*hiera_default_config_key*]
+#   Default: gitlab_ci_runners_defaults 
+#   Name of hiera hash with default configs for CI Runners.
+#   The config is the parameters for the /usr/bin/gitlab-ci-multi-runner register
+#   command.
+#
+# [*hiera_runners_key*]
+#   Default: gitlab_ci_runners
+#   Name of hiera hash with individual runners to be installed.
+#
+# === Authors
+#
+# Tobias Brunner <tobias.brunner@vshn.ch>
+# Matthias Indermuehle <matthias.indermuehle@vshn.ch>
+#
+# === Copyright
+#
+# Copyright 2015 Tobias Brunner, VSHN AG
+#
+class gitlab::cirunner (
+  $hiera_default_config_key = 'gitlab_ci_runners_defaults',
+  $hiera_runners_key = 'gitlab_ci_runners',
+  $manage_docker = true,
+  $manage_repo = true,
+) {
+
+  validate_string($hiera_default_config_key)
+  validate_string($hiera_runners_key)
+  validate_bool($manage_docker)
+  validate_bool($manage_repo)
+  unless ($::osfamily == 'Debian') {
+    fail ("OS family ${::osfamily} is not supported. Only Debian is suppported.")
+  }
+
+  if $manage_docker {
+    include ::docker
+
+    $docker_images = {
+      ubuntu_trusty => {
+        image => 'ubuntu',
+        image_tag => 'trusty',
+      },
+    }
+    class { '::docker::images':
+      images => $docker_images,
+    }
+  }
+
+  $distid = downcase($::lsbdistid)
+  if $manage_repo {
+    ::apt::source { 'apt_gitlabci':
+      comment  => 'GitlabCI Runner Repo',
+      location => "https://packages.gitlab.com/runner/gitlab-ci-multi-runner/${distid}/",
+      release  => $::lsbdistcodename,
+      repos    => 'main',
+      key      => {
+        'id' => '1A4C919DB987D435939638B914219A96E15E78F4',
+        'server' => 'keys.gnupg.net',
+      },
+      include  => {
+        'src' => false,
+        'deb' => true,
+      }
+    }
+    Apt::Source['apt_gitlabci'] -> Package['gitlab-ci-multi-runner']
+    Exec['apt_update'] -> Package['gitlab-ci-multi-runner']
+  }
+  package { 'gitlab-ci-multi-runner':
+  	ensure => 'present',
+  }
+
+  $runners_hash = hiera($hiera_runners_key, {})
+  $runners = keys($runners_hash)
+  $default_config = hiera($hiera_default_config_key, {})
+  gitlab::runner { $runners:
+    default_config => $default_config,
+    runners_hash   => $runners_hash,
+  }
+}

--- a/manifests/runner.pp
+++ b/manifests/runner.pp
@@ -1,0 +1,55 @@
+# == Define: gitlab::runner
+#
+# This module installs and configures Gitlab CI Runners.
+#
+# === Parameters
+#
+# [*runners_hash*]
+#   Hash with configuration for runners
+#
+# [*default_config*]
+#   Hash with default configration for runners. This will
+#   be merged with the runners_hash config
+#
+# === Authors
+#
+# Tobias Brunner <tobias.brunner@vshn.ch>
+# Matthias Indermuehle <matthias.indermuehle@vshn.ch>
+#
+# === Copyright
+#
+# Copyright 2015 Tobias Brunner, VSHN AG
+#
+define gitlab::runner (
+  $runners_hash,
+  $default_config = {},
+) {
+
+  validate_hash($runners_hash)
+  validate_hash($default_config)
+
+  # Set resource name as name for the runner
+  $name_config = {
+    name => $title,
+  }
+  $_default_config = merge($default_config, $name_config)
+  $config = $runners_hash[$title]
+
+  # Merge default config with actual config
+  $_config = merge($_default_config, $config)
+
+  # Convert configuration into a string
+  $parameters_array = join_keys_to_values($_config, " ")
+  $parameters_array_dashes = prefix($parameters_array, "--")
+  $parameters_string = join($parameters_array_dashes, " ")
+
+  $runner_name = $_config['name']
+  $toml_file = '/etc/gitlab-runner/config.toml'
+
+  # Execute gitlab ci multirunner register
+  exec {"Register_runner_${title}":
+    command => "/usr/bin/gitlab-ci-multi-runner register -n ${parameters_string}",
+    unless  => "/bin/grep ${runner_name} ${toml_file}",
+  }
+
+}

--- a/spec/classes/cirunner_spec.rb
+++ b/spec/classes/cirunner_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe 'gitlab::cirunner' do
+  context 'supported operating systems' do
+    describe "gitlab::cirunner class without any parameters on Ubuntu Trusty" do
+      let(:params) {{ }}
+      let(:facts) {{
+        :osfamily => 'Debian',
+        :lsbdistid => 'Ubuntu',
+        :lsbdistcodename => 'trusty',
+      }}
+
+      it { is_expected.to compile.with_all_deps }
+
+      it { is_expected.to contain_class('docker') }
+      it { is_expected.to contain_class('docker::images') }
+      it { is_expected.to contain_apt__source('apt_gitlabci') }
+
+      it { is_expected.to contain_package('gitlab-ci-multi-runner').with_ensure('present') }
+    end
+    describe "gitlab class without any parameters on RedHat (CentOS)" do
+      let(:params) {{ }}
+      let(:facts) {{
+        :osfamily => 'redhat',
+      }}
+
+      it { expect { is_expected.to contain_package('gitlab') }.to raise_error(Puppet::Error, /OS family redhat is not supported. Only Debian is suppported./) }
+    end
+  end
+
+end


### PR DESCRIPTION
From Issue #21 

This change has a new class to setup Gitlab CI Runners

* Install Docker
* Install Gitlab CI Runner Repo
* Install Gitlab CI Multi Runner
* Create runners

It can be used independently from the rest of the Gitlab module