### PR TITLE
Add 'manage_package' parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,6 +16,10 @@
 #   Default: true
 #   Should the official package repository be managed?
 #
+# [*manage_package*]
+#   Default: true
+#   Should the GitLab package be managed?
+#
 # [*service_name*]
 #   Default: gitlab-runsvdir
 #   Name of the system service.
@@ -200,6 +204,7 @@
 class gitlab (
   # package installation handling
   $manage_package_repo = $::gitlab::params::manage_package_repo,
+  $manage_package = $::gitlab::params::manage_package,
   $package_ensure = $::gitlab::params::package_ensure,
   $package_pin = $::gitlab::params::package_pin,
   # system service configuration
@@ -252,6 +257,7 @@ class gitlab (
 
   # package installation handling
   validate_bool($manage_package_repo)
+  validate_bool($manage_package)
   # system service configuration
   validate_string($service_name)
   validate_bool($service_enable)

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -6,6 +6,7 @@ class gitlab::install {
 
   $edition             = $::gitlab::edition
   $manage_package_repo = $::gitlab::manage_package_repo
+  $manage_package      = $::gitlab::manage_package
   $package_ensure      = $::gitlab::package_ensure
   $package_name        = "gitlab-${edition}"
   $package_pin         = $::gitlab::package_pin
@@ -15,7 +16,6 @@ class gitlab::install {
     case $::osfamily {
       'debian': {
         include apt
-        Exec['apt_update'] -> Package[$package_name]
         $_lower_os = downcase($::operatingsystem)
         apt::source { 'gitlab_official':
           comment  => 'Official repository for Gitlab',
@@ -30,9 +30,15 @@ class gitlab::install {
             src    => true,
             deb    => true,
           },
-        } ->
-        package { $package_name:
-          ensure => $package_ensure,
+        }
+        if $manage_package { 
+          package { $package_name:
+            ensure => $package_ensure,
+            require => [
+              Exec['apt_update'],
+              Apt::Source['gitlab_official'],
+            ],
+          }
         }
         if $package_pin {
           apt::pin { 'hold-gitlab':
@@ -58,16 +64,20 @@ class gitlab::install {
           repo_gpgcheck => 1,
           sslcacert     => '/etc/pki/tls/certs/ca-bundle.crt',
           sslverify     => 1,
-        } ->
-        package { $package_name:
-          ensure => $package_ensure,
+        }
+
+        if $manage_package {
+          package { $package_name:
+            ensure  => $package_ensure,
+            require => Yumrepo['gitlab_official'],
+          }
         }
       }
       default: {
         fail("OS family ${::osfamily} not supported")
       }
     }
-  } else {
+  } elsif $manage_package  {
     package { $package_name:
       ensure => $package_ensure,
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,6 +9,7 @@ class gitlab::params {
   $package_ensure = installed
   $package_pin = false
   $manage_package_repo = true
+  $manage_package = true
 
   # service parameters
   case $::osfamily {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -184,5 +184,11 @@ describe 'gitlab' do
         .with_content(/^\s*mattermost\['enable'\] = true$/)
       }
     end
+    describe 'with manage_package => false' do
+      let(:params) {{:manage_package => false }}
+
+      it { should_not contain_package('gitlab-ce') }
+      it { should_not contain_package('gitlab-ee') }
+    end
   end
 end


### PR DESCRIPTION
Some installations require modification before configuration, thus it
is desirable to be able to unmanage the package in this module, install
and modify it with another, then use this module to configure the
installation.  As an example, it is nice to be able to add additional
omniauth providers after installing the omnibus package, but before
configuring it.