### PR TITLE
Fix this module should work with out having to set the stringify_facts option

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -52,7 +52,7 @@ class gitlab::install {
         if is_hash($::os) {
           $releasever = $::os[release][major]
         } else {
-          $releasever = "\$releasever"
+          $releasever = $::operatingsystemmajrelease 
         }
 
         yumrepo { 'gitlab_official':


### PR DESCRIPTION
Since falling back to $releasever will likely never work as it espands to 7server or 6server everywhere I tested update the module to use the $::operatingsystemmajrelease fact when the is_hash test fails for $::os.  There may be a better way to handle this and I am willing to change it with proper feedback.  I would also like to understand the reasoning behind usng the $:os hash instead of the $::operatingsystemmajrelease fact. Maybe the best way would be to just use this instead?