### PR TITLE
service enabled for all distro's #27

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,18 +11,7 @@ class gitlab::params {
   $manage_package_repo = true
   $manage_package = true
 
-  # service parameters
-  case $::osfamily {
-    'debian': {
-      $service_enable = true
-    }
-    'redhat': {
-      $service_enable = false
-    }
-    default: {
-      $service_enable = true
-    }
-  }
+  $service_enable = true
 
   $service_exec = '/usr/bin/gitlab-ctl'
   $service_restart = "$service_exec restart"


### PR DESCRIPTION
As the documentation says, that the default for service_enabled is true, this should be true then for all distros.  
This is tested on centos7.1 and the latest gitlab 8.2.3

Issue #27 could be closed with this PR.

No rspec is changed since this kind of test is not covered. 
