### PR TITLE
Added code for configuration of a cli and adding of a user with that cli

### DIFF
--- a/manifests/cli.pp
+++ b/manifests/cli.pp
@@ -31,10 +31,7 @@ class gitlab::cli(
   # this API call this way it will work in the first puppet run
   exec { 'gitlab-settings':
     command => "/bin/echo export GITLAB_API_PRIVATE_TOKEN=`/bin/curl -s -X POST -d 'password=${gitlab_api_password}&login=${gitlab_api_user}' ${gitlab_api_endpoint}/session | /bin/jq .private_token -r` > ~/.gitlab; /bin/echo export GITLAB_API_ENDPOINT=${gitlab_api_endpoint} >> ~/.gitlab",
-    onlyif  => [
-      "/bin/test -f ~/.gitlab", 
-      "/bin/grep GITLAB_API_PRIVATE_TOKEN ~/.gitlab", 
-      "/bin/grep GITLAB_API_ENDPOINT ~/.gitlab" ],
+    unless  => "/bin/test -f ~/.gitlab && /bin/grep '^export GITLAB_API_PRIVATE_TOKEN.*$' ~/.gitlab 1>/dev/null && /bin/grep '^export GITLAB_API_ENDPOINT.*$' ~/.gitlab 1>/dev/null",
     require => $exec_dependencies,
   }
   

--- a/manifests/cli.pp
+++ b/manifests/cli.pp
@@ -1,0 +1,41 @@
+class gitlab::cli(
+  $gitlab_api_endpoint     = $::gitlab::params::gitlab_api_endpoint,
+  $gitlab_api_password     = $::gitlab::params::gitlab_api_password,
+  $gitlab_api_user         = $::gitlab::params::gitlab_api_user,
+  $manage_cli_dependencies = $::gitlab::params::manage_cli_dependencies,
+  ) {
+
+  # input validation
+  validate_bool($manage_cli_dependencies)
+  validate_string($gitlab_api_endpoint, $gitlab_api_password, $gitlab_api_user)
+
+  # check if we need to manage dependencies
+  if $manage_cli_dependencies {
+    $gem_dependencies  = [ Package['rubygems'], Package['ruby-devel'] ]
+    $exec_dependencies = [ Package['curl'], Package['jq'],  ]
+  } else {
+    $gem_dependencies  = undef
+    $exec_dependencies = undef
+  }
+
+  # set up the gitlab gem to have gitlab cli support
+  package { 'gitlab':
+    ensure   => installed,
+    provider => 'gem',
+    require  => $gem_dependencies,
+  } ->
+
+  # we retrieve the private token with a simple raw curl API call. Reason for 
+  # this is to make initial deployment work: gitlab gets installed with a
+  # user/pw combo root/5ifeL!fe and an auto-generated private token. By doing 
+  # this API call this way it will work in the first puppet run
+  exec { 'gitlab-settings':
+    command => "/bin/echo export GITLAB_API_PRIVATE_TOKEN=`/bin/curl -s -X POST -d 'password=${gitlab_api_password}&login=${gitlab_api_user}' ${gitlab_api_endpoint}/session | /bin/jq .private_token -r` > ~/.gitlab; /bin/echo export GITLAB_API_ENDPOINT=${gitlab_api_endpoint} >> ~/.gitlab",
+    onlyif  => [
+      "/bin/test -f ~/.gitlab", 
+      "/bin/grep GITLAB_API_PRIVATE_TOKEN ~/.gitlab", 
+      "/bin/grep GITLAB_API_ENDPOINT ~/.gitlab" ],
+    require => $exec_dependencies,
+  }
+  
+}

--- a/manifests/cli.pp
+++ b/manifests/cli.pp
@@ -12,14 +12,14 @@ class gitlab::cli(
   # check if we need to manage dependencies
   if $manage_cli_dependencies {
     $gem_dependencies  = [ Package['rubygems'], Package['ruby-devel'] ]
-    $exec_dependencies = [ Package['curl'], Package['jq'],  ]
+    $exec_dependencies = [ Package['curl'], Package['jq'], ]
   } else {
     $gem_dependencies  = undef
     $exec_dependencies = undef
   }
 
   # set up the gitlab gem to have gitlab cli support
-  package { 'gitlab':
+  package { 'gitlab-cli':
     ensure   => installed,
     provider => 'gem',
     require  => $gem_dependencies,

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -6,15 +6,6 @@ define gitlab::user(
   ) {
   
   validate_string($username, $email, $password, $fullname)
-
-  exec { "create-user-${title}":
-    command => "source ~/.gitlab; /usr/local/bin/gitlab '${email}' '${password}' '${username}' '{name: \"${fullname}\"}'",
-    onlyif  => [ 
-      "source ~/.gitlab; /usr/local/bin/gitlab users | grep $email",
-      "source ~/.gitlab; /usr/local/bin/gitlab users | grep $username",
-    ],
-    require => Package['gitlab-cli'],
-  }
   
   exec { "create-user-${title}":
     command => "/bin/bash -c 'source /root/.gitlab; /usr/local/bin/gitlab create_user \"${email}\" \"${password}\" \"${username}\" \"{name: \\\"${fullname}\\\"}\"'",

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -1,0 +1,19 @@
+class gitlab::user(
+  $username,
+  $email,
+  $password,
+  $fullname,
+  ) {
+  
+  validate_string($username, $email, $password, $fullname)
+
+  exec { "create-user-${title}":
+    command => "source ~/.gitlab; /usr/local/bin/gitlab '${email}' '${password}' '${username}' '{name: \"${fullname}\"}'",
+    onlyif  => [ 
+      "source ~/.gitlab; /usr/local/bin/gitlab users | grep $email",
+      "source ~/.gitlab; /usr/local/bin/gitlab users | grep $username",
+    ],
+    require => Package['gitlab-cli'],
+  }
+
+}

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -1,4 +1,4 @@
-class gitlab::user(
+define gitlab::user(
   $username,
   $email,
   $password,
@@ -15,5 +15,12 @@ class gitlab::user(
     ],
     require => Package['gitlab-cli'],
   }
-
+  
+  exec { "create-user-${title}":
+    command => "/bin/bash -c 'source /root/.gitlab; /usr/local/bin/gitlab create_user \"${email}\" \"${password}\" \"${username}\" \"{name: \\\"${fullname}\\\"}\"'",
+    unless  => "/bin/bash -c 'source /root/.gitlab; /usr/local/bin/gitlab users | /bin/grep $email'",
+    path    => '/bin:/usr/local/bin',
+    environment => 'HOME=/root',
+    require => Package['gitlab-cli'],
+  }
 }


### PR DESCRIPTION
With standard gitlab omnibus installer for gitlab 8 there's no cli to interface with gitlab. This PR configures the gitlab gem and a config file that then allows the gitlab::user class to create users.

Eventually the gitlab::user class needs to become a custom type and provider, but for now this will do.