### PR TITLE
Fixes Docker tag

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -6,6 +6,6 @@ fixtures:
       ref: "2.2.0"
     docker:
       repo: "https://github.com/garethr/garethr-docker.git"
-      ref: "4.1.1"
+      ref: "v4.1.1"
   symlinks:
     gitlab: "#{source_dir}"


### PR DESCRIPTION
Error before:
```
fatal: ambiguous argument '4.1.1': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```