### PR TITLE
Fix rspec tests

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -6,6 +6,6 @@ fixtures:
       ref: "2.2.0"
     docker:
       repo: "https://github.com/garethr/garethr-docker.git"
-      ref: "4.1.1"
+      ref: "v4.1.1"
   symlinks:
     gitlab: "#{source_dir}"

--- a/spec/classes/cirunner_spec.rb
+++ b/spec/classes/cirunner_spec.rb
@@ -8,6 +8,9 @@ describe 'gitlab::cirunner' do
         :osfamily => 'Debian',
         :lsbdistid => 'Ubuntu',
         :lsbdistcodename => 'trusty',
+        :operatingsystem => 'Debian',
+        :operatingsystemmajrelease => 'jessie/sid',
+        :kernelrelease => '3.13.0-71-generic',
       }}
 
       it { is_expected.to compile.with_all_deps }
@@ -22,6 +25,22 @@ describe 'gitlab::cirunner' do
       let(:params) {{ }}
       let(:facts) {{
         :osfamily => 'redhat',
+        :operatingsystem => 'CentOS',
+        :operatingsystemmajrelease => '6',
+        :os              => {
+          :architecture => "x86_64",
+          :family => "RedHat",
+          :hardware => "x86_64",
+          :name => "CentOS",
+          :release => {
+            :full => "6.7",
+            :major => "6",
+            :minor => "7"
+          },
+          :selinux => {
+            :enabled => false
+          }
+        },
       }}
 
       it { expect { is_expected.to contain_package('gitlab') }.to raise_error(Puppet::Error, /OS family redhat is not supported. Only Debian is suppported./) }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -8,6 +8,7 @@ describe 'gitlab' do
         :osfamily => 'debian',
         :lsbdistid => 'debian',
         :lsbdistcodename => 'jessie',
+        :operatingsystem => 'Debian',
       }}
 
       it { is_expected.to compile.with_all_deps }
@@ -28,6 +29,21 @@ describe 'gitlab' do
       let(:params) {{ }}
       let(:facts) {{
         :osfamily => 'redhat',
+        :operatingsystem => 'CentOS',
+        :os              => {
+          :architecture => "x86_64",
+          :family => "RedHat",
+          :hardware => "x86_64",
+          :name => "CentOS",
+          :release => {
+            :full => "6.7",
+            :major => "6",
+            :minor => "7"
+          },
+          :selinux => {
+            :enabled => false
+          }
+        },
       }}
 
       it { is_expected.to compile.with_all_deps }
@@ -59,6 +75,7 @@ describe 'gitlab' do
       :osfamily => 'debian',
       :lsbdistid => 'debian',
       :lsbdistcodename => 'jessie',
+      :operatingsystem => 'Debian',
     }}
 
     describe 'edition = ce' do


### PR DESCRIPTION
All tests are currently failing in Travis due to STRICT_VARIABLES. Fixed by configuring missing mocked facts.

Also fixes Docker tag in fixtures