### PR TITLE
Do not enable service by default on RHEL6

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,8 +11,6 @@ class gitlab::params {
   $manage_package_repo = true
   $manage_package = true
 
-  $service_enable = true
-
   $service_exec = '/usr/bin/gitlab-ctl'
   $service_restart = "${service_exec} restart"
   $service_start = "${service_exec} start"
@@ -26,6 +24,12 @@ class gitlab::params {
   $service_name = 'gitlab-runsvdir'
   $service_user = 'root'
   $service_group = 'root'
+
+  if $::osfamily == 'RedHat' and $::operatingsystemmajrelease == '6' {
+    $service_enable = false
+  } else {
+    $service_enable = true
+  }
 
   # gitlab specific
   $config_file = '/etc/gitlab/gitlab.rb'


### PR DESCRIPTION
```
Error: Could not enable gitlab-runsvdir: Execution of '/sbin/chkconfig --add gitlab-runsvdir' returned 1: service gitlab-runsvdir does not support chkconfig
Error: /Stage[main]/Gitlab::Service/Service[gitlab-runsvdir]/enable: change from false to true failed: Could not enable gitlab-runsvdir: Execution of '/sbin/chkconfig --add gitlab-runsvdir' returned 1: service gitlab-runsvdir does not support chkconfig
```

Fixes #50