### PR TITLE
Allow settings of custom gitlab.rb config file

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -39,6 +39,7 @@ class gitlab::config {
   $service_user = $::gitlab::service_user
   $shell = $::gitlab::shell
   $sidekiq = $::gitlab::sidekiq
+  $source_config_file = $::gitlab::source_config_file
   $unicorn = $::gitlab::unicorn
   $gitlab_workhorse = $::gitlab::gitlab_workhorse
   $user = $::gitlab::user
@@ -65,12 +66,22 @@ class gitlab::config {
     $_real_pages_nginx = $pages_nginx
   }
 
-  file { $config_file:
+  if $source_config_file != nil{
+    file { $config_file:
+      ensure  => file,
+      owner   => $service_user,
+      group   => $service_group,
+      mode    => '0600',
+      source => $source_config_file;
+    }
+  } else {
+    file { $config_file:
       ensure  => file,
       owner   => $service_user,
       group   => $service_group,
       mode    => '0600',
       content => template('gitlab/gitlab.rb.erb');
+    }
   }
 
   if ! empty($secrets) {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -187,6 +187,10 @@
 #   Default: undef
 #   Hash of 'sidekiq' config parameters.
 #
+# [*source_config_file*]
+#   Default: undef
+#   Override Hiera config with path to gitlab.rb config file.
+#
 # [*unicorn*]
 #   Default: undef
 #   Hash of 'unicorn' config parameters.
@@ -274,6 +278,7 @@ class gitlab (
   $secrets_file = $::gitlab::params::secrets_file,
   $shell = undef,
   $sidekiq = undef,
+  $source_config_file = undef,
   $unicorn = undef,
   $gitlab_workhorse = undef,
   $user = undef,


### PR DESCRIPTION
Gives the ability to set the gitlab.rb config file to your own puppet path overriding hiera.