### PR TITLE
Added registry configuration hash option

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -33,6 +33,7 @@ class gitlab::config {
   $pages_nginx_eq_nginx = $::gitlab::pages_nginx_eq_nginx
   $postgresql = $::gitlab::postgresql
   $redis = $::gitlab::redis
+  $registry = $::gitlab::registry
   $registry_nginx = $::gitlab::registry_nginx
   $registry_nginx_eq_nginx = $::gitlab::registry_nginx_eq_nginx
   $registry_external_url = $::gitlab::registry_external_url

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -174,6 +174,10 @@
 #   Default: undef
 #   Hash of 'redis' config parameters.
 #
+# [*registry*]
+#   Default: undef
+#   Hash of 'registry' config parameters.
+#
 # [*registry_external_url*]
 #  Default: undef
 #  External URL of Registry
@@ -287,6 +291,7 @@ class gitlab (
   $pages_nginx_eq_nginx = false,
   $postgresql = undef,
   $redis = undef,
+  $registry = undef,
   $registry_external_url = undef,
   $registry_nginx = undef,
   $registry_nginx_eq_nginx = false,
@@ -339,6 +344,7 @@ class gitlab (
   validate_bool($pages_nginx_eq_nginx)
   if $postgresql { validate_hash($postgresql) }
   if $redis { validate_hash($redis) }
+  if $registry { validate_hash($registry) }
   if $registry_nginx { validate_hash($registry_nginx) }
   validate_bool($registry_nginx_eq_nginx)
   if $registry_external_url { validate_string($registry_external_url) }

--- a/templates/gitlab.rb.erb
+++ b/templates/gitlab.rb.erb
@@ -191,6 +191,15 @@ omnibus_gitconfig['<%= k -%>'] = <%= decorate(@git[k]) %>
 
 ci_external_url '<%= @ci_external_url %>'
 <%- end -%>
+<%- if @registry -%>
+
+############################
+# registry configuration   #
+############################
+
+<%- @registry.keys.sort.each do |k| -%>
+registry['<%= k -%>'] = <%= decorate(@registry[k]) %>
+<%- end end -%>
 <%- if @gitlab_ci -%>
 
 #################################


### PR DESCRIPTION
Relates to #74, #76 
Credits to #77 

Added missing registry configuration hash. See https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/files/gitlab-config-template/gitlab.rb.template#L319