### PR TITLE
Allow "Disable storage directories management"

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -22,6 +22,7 @@ class gitlab::config {
   $high_availability = $::gitlab::high_availability
   $logging = $::gitlab::logging
   $logrotate = $::gitlab::logrotate
+  $manage_storage_directories = $::gitlab::manage_storage_directories
   $manage_accounts = $::gitlab::manage_accounts
   $mattermost = $::gitlab::mattermost
   $mattermost_external_url = $::gitlab::mattermost_external_url

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -130,6 +130,10 @@
 #   Default: undef
 #   Hash of 'logrotate' config parameters.
 #
+# [*manage_storage_directories*]
+#   Default: undef
+#   Hash of 'manage_storage_directories' config parameters.
+#
 # [*manage_accounts*]
 #   Default: undef
 #   Hash of 'manage_accounts' config parameters.
@@ -284,6 +288,7 @@ class gitlab (
   $high_availability = undef,
   $logging = undef,
   $logrotate = undef,
+  $manage_storage_directories = undef,
   $manage_accounts = undef,
   $mattermost = undef,
   $mattermost_external_url = undef,
@@ -340,6 +345,7 @@ class gitlab (
   if $gitlab_rails { validate_hash($gitlab_rails) }
   if $logging { validate_hash($logging) }
   if $logrotate { validate_hash($logrotate) }
+  if $manage_storage_directories { validate_hash($manage_storage_directories) }
   if $nginx { validate_hash($nginx) }
   if $mattermost { validate_hash($mattermost) }
   if $mattermost_external_url { validate_string($mattermost_external_url) }

--- a/templates/gitlab.rb.erb
+++ b/templates/gitlab.rb.erb
@@ -170,6 +170,19 @@ logging['<%= k -%>'] = <%= decorate(@logging[k]) %>
 <%- @logrotate.keys.sort.each do |k| -%>
 logrotate['<%= k -%>'] = <%= decorate(@logrotate[k]) %>
 <%- end end -%>
+<%- if @manage_storage_directories -%>
+
+#######################
+# Storage directories #
+#######################
+## Disable managing storage directories
+## Set only if the select directories are created manually
+## See: http://doc.gitlab.com/omnibus/settings/configuration.html#disable-storage-directories-management
+# manage_storage_directories['enable'] = false
+
+<%- @manage_storage_directories.keys.sort.each do |k| -%>
+manage_storage_directories['<%= k -%>'] = <%= decorate(@manage_storage_directories[k]) %>
+<%- end end -%>
 <%- if @git -%>
 
 #######


### PR DESCRIPTION
In environments that use shared  storage (ex. NFS) required directories might/will already exist. Running puppet module against a setup like that will try to re-create the directories and change their permissions. This stops GitLab from functioning correctly as it is not able to access the filesystem. This commit fixes it by allowing the users to set 'manage_storage_directores[enable]=false' as per https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/doc/settings/configuration.md#disable-storage-directories-management