### PR TITLE
Added external_port parameter

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -13,6 +13,7 @@ class gitlab::config {
   $config_manage = $::gitlab::config_manage
   $config_file = $::gitlab::config_file
   $external_url = $::gitlab::external_url
+  $external_port = $::gitlab::external_port
   $git = $::gitlab::git
   $git_data_dir = $::gitlab::git_data_dir
   $gitlab_git_http_server = $::gitlab::gitlab_git_http_server

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -94,6 +94,10 @@
 #   Default: undef
 #   External URL of Gitlab.
 #
+# [*external_port*]
+#   Default: undef
+#   External PORT of Gitlab.
+#
 # [*git*]
 #   Default: undef
 #   Hash of 'omnibus_gitconfig' config parameters.
@@ -275,6 +279,7 @@ class gitlab (
   $config_manage = $::gitlab::params::config_manage,
   $config_file = $::gitlab::params::config_file,
   $external_url = undef,
+  $external_port = undef,
   $git = undef,
   $git_data_dir = undef,
   $gitlab_git_http_server = undef,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -93,6 +93,12 @@ describe 'gitlab' do
         .with_content(/^\s*external_url 'http:\/\/gitlab\.mycompany\.com\/'$/)
       }
     end
+    describe 'external_port' do
+      let(:params) { {:external_port => 987654} }
+      it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') \
+        .with_content(/^\s*external_port '987654'$/)
+      }
+    end
     describe 'ci_external_url' do
       let(:params) { {:ci_external_url => 'http://gitlabci.mycompany.com/'} }
       it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') \

--- a/templates/gitlab.rb.erb
+++ b/templates/gitlab.rb.erb
@@ -35,6 +35,9 @@ end -%>
 ## For more details on configuring external_url see:
 ## https://gitlab.com/gitlab-org/omnibus-gitlab/blob/629def0a7a26e7c2326566f0758d4a27857b52a3/README.md#configuring-the-external-url-for-gitlab
 external_url '<%= @external_url %>'
+<%- if @external_port -%>
+external_port '<%= @external_port %>'
+<%- end -%>
 <%- if @git_data_dir -%>
 
 ## For setting up different data storing directory


### PR DESCRIPTION
I'm using Gitlab that sit's behind an Nginx reverse proxy, and needed to change the external port. So I've added the `external_port` parameter. Note that to successfully use a different port, you need to add the port to the `external_url` as well. I'm currently using this fork, and it works as expected. I've also added a basic test. Please let me know if you have any concerns.

```puppet
class { 'gitlab':
  external_url  => 'http://domain.name:5555',
  external_port => 5555,
}
```