### PR TITLE
Add systemd_compatibility

### DIFF
--- a/lib/facter/gitlab_systemd.rb
+++ b/lib/facter/gitlab_systemd.rb
@@ -1,0 +1,18 @@
+# Fact: gitlab_systemd
+#
+# Purpose: 
+#   Determine whether SystemD is the init system on the node
+#
+# Resolution:
+#   Check the name of the process 1 (ps -p 1)
+#
+# Caveats:
+#	Duplicates the fact "systemd" from camptocamp/puppet-systemd
+#
+
+Facter.add(:gitlab_systemd) do
+  confine :kernel => :linux
+  setcode do
+    Facter::Util::Resolution.exec('ps -p 1 -o comm=') == 'systemd'
+  end
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,6 +28,12 @@
 #   Default: true
 #   Run the system service on boot.
 #
+# [*service_initd_ensure*]
+#   Default for systemd systems, as determined by the $::gitlab_systemd fact: "absent"
+#   Else: "link"
+#   Sets "ensure => 'absent'" or "ensure => 'link'" on init.d softlink
+#   depending on the $::gitlab_systemd fact to avoid conflicts with systemd.
+#
 # [*service_exec*]
 #   Default: '/usr/bin/gitlab-ctl'
 #   The service executable path.
@@ -261,6 +267,7 @@ class gitlab (
   $package_pin = $::gitlab::params::package_pin,
   # system service configuration
   $service_enable = $::gitlab::params::service_enable,
+  $service_initd_ensure = $::gitlab::params::service_initd_ensure,
   $service_ensure = $::gitlab::params::service_ensure,
   $service_group = $::gitlab::params::service_group,
   $service_hasrestart = $::gitlab::params::service_hasrestart,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -31,6 +31,12 @@ class gitlab::params {
     $service_enable = true
   }
 
+  if ($::gitlab_systemd) {
+    $service_initd_ensure = 'absent'
+  } else {
+    $service_initd_ensure = 'link'
+  }
+
   # gitlab specific
   $config_manage = true
   $config_file = '/etc/gitlab/gitlab.rb'

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -6,7 +6,7 @@
 class gitlab::service {
   if $::gitlab::service_manage {
     file { "/etc/init.d/${::gitlab::service_name}":
-      ensure => 'link',
+      ensure => $::gitlab::service_initd_ensure,
       target => $::gitlab::service_exec,
     } ->
     service { $::gitlab::service_name:

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -5,6 +5,7 @@ describe 'gitlab' do
     describe "gitlab class without any parameters on Debian (Jessie)" do
       let(:params) {{ }}
       let(:facts) {{
+        :gitlab_systemd  => false,
         :osfamily => 'debian',
         :lsbdistid => 'debian',
         :lsbdistcodename => 'jessie',
@@ -28,6 +29,7 @@ describe 'gitlab' do
     describe "gitlab class without any parameters on RedHat (CentOS)" do
       let(:params) {{ }}
       let(:facts) {{
+        :gitlab_systemd  => false,
         :osfamily => 'redhat',
         :operatingsystem => 'CentOS',
         :operatingsystemmajrelease => '6',
@@ -63,6 +65,7 @@ describe 'gitlab' do
   context 'unsupported operating system' do
     describe 'gitlab class without any parameters on Solaris/Nexenta' do
       let(:facts) {{
+        :gitlab_systemd  => false,
         :osfamily        => 'Solaris',
         :operatingsystem => 'Nexenta',
       }}
@@ -71,8 +74,61 @@ describe 'gitlab' do
     end
   end
 
+  context 'linking init script on non-systemd' do
+    describe 'gitlab class on a non-systemd machine' do
+      let(:facts) {{
+        :gitlab_systemd => false,
+        :osfamily => 'redhat',
+        :operatingsystem => 'CentOS',
+        :operatingsystemmajrelease => '6',
+        :os              => {
+          :architecture => "x86_64",
+          :family => "RedHat",
+          :hardware => "x86_64",
+          :name => "CentOS",
+          :release => {
+            :full => "6.7",
+            :major => "6",
+            :minor => "7"
+          },
+          :selinux => {
+            :enabled => false
+          }
+        },
+      }}
+
+      it { is_expected.to contain_file('/etc/init.d/gitlab-runsvdir').with_ensure('link') }
+    end
+
+    describe 'gitlab class on a systemd machine' do
+      let(:facts) {{
+        :gitlab_systemd => true,
+        :osfamily => 'redhat',
+        :operatingsystem => 'CentOS',
+        :operatingsystemmajrelease => '6',
+        :os              => {
+          :architecture => "x86_64",
+          :family => "RedHat",
+          :hardware => "x86_64",
+          :name => "CentOS",
+          :release => {
+            :full => "7.2",
+            :major => "7",
+            :minor => "2"
+          },
+          :selinux => {
+            :enabled => false
+          }
+        },
+      }}
+
+      it { is_expected.to contain_file('/etc/init.d/gitlab-runsvdir').with_ensure('absent') }
+    end
+  end
+
   context 'gitlab specific parameters' do
     let(:facts) {{
+      :gitlab_systemd  => false,
       :osfamily => 'debian',
       :lsbdistid => 'debian',
       :lsbdistcodename => 'jessie',


### PR DESCRIPTION
* Ensure absent softlink in init.d for operating systems with systemd.
* Updated init.pp description of "service_initd_ensure" to reflect recent changes.
* Added custom fact gitlab_systemd (duplicates fact from camptocamp-systemd, but we dont want full module for just one fact)
* Adds spec to test new systemd functionality
* New fact added to all tests to avoid errors with `STRICT_VARIABLES=yes`

Rebase, squash with tests from #90 