### PR TITLE
Fixes beaker tests

### DIFF
--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -47,7 +47,7 @@ describe 'gitlab class' do
 
     context 'allows http connection on port 80' do
       describe command('curl 0.0.0.0:80/users/sign_in') do
-        its(:stdout) { should match /reset_password_token/ }
+        its(:stdout) { should match /reset_password_token|GitLab/ }
       end
     end
 


### PR DESCRIPTION
* Beaker tests when run in a small enough container (such as a Travis box) the Gitlab app can fail with (`Whoops, GitLab is taking too much time to respond.`)
* So we change the regex to see that also, so we can at least see the app has been attempted to start