### PR TITLE
Refactor beaker tests for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,13 +25,13 @@ matrix:
       sudo: required
       services: docker
       env: BEAKER_set="ubuntu-server-1204-docker" PUPPET_INSTALL_TYPE=foss
-      script: bundle exec rake acceptance
+      script: bundle exec rspec spec/acceptance/travis_ci_acceptance_spec.rb
       bundler_args: --without development
     - rvm: '2.1'
       sudo: required
       services: docker
       env: BEAKER_set="centos-6-docker" PUPPET_INSTALL_TYPE=foss
-      script: bundle exec rake acceptance
+      script: bundle exec rspec spec/acceptance/travis_ci_acceptance_spec.rb
       bundler_args: --without development
   allow_failures:
     - env: BEAKER_set="ubuntu-server-1204-docker" PUPPET_INSTALL_TYPE=foss

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -64,6 +64,12 @@
 #   Default: true
 #   The gitlab service has this commands available.
 #
+# [*service_provider*]
+#   Default: base
+#   The provider Puppet will use to start the service
+#   Since gitlab-ctl is a supervisor process, we use base and run
+#   the commands via runsvdir
+#
 # [*edition*]
 #   Default: ce
 #   Gitlab edition to install. ce or ee.
@@ -280,6 +286,7 @@ class gitlab (
   $service_status = $::gitlab::params::service_status,
   $service_stop = $::gitlab::params::service_stop,
   $service_user = $::gitlab::params::service_user,
+  $service_provider = $::gitlab::params::service_provider,
   # gitlab specific
   $edition = 'ce',
   $ci_external_url = undef,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,6 +24,7 @@ class gitlab::params {
   $service_name = 'gitlab-runsvdir'
   $service_user = 'root'
   $service_group = 'root'
+  $service_provider = 'base'
 
   if $::osfamily == 'RedHat' and $::operatingsystemmajrelease == '6' {
     $service_enable = false

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -18,6 +18,7 @@ class gitlab::service {
       status     => $::gitlab::service_status,
       hasstatus  => $::gitlab::service_hasstatus,
       hasrestart => $::gitlab::service_hasrestart,
+      provider   => $::gitlab::service_provider,
     }
   }
 

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -7,8 +7,7 @@ describe 'gitlab class' do
     it 'should work idempotently with no errors' do
       pp = <<-EOS
       class { 'gitlab':
-        external_url   => "http://${::fqdn}",
-        service_manage => false,
+        external_url => "http://${::fqdn}",
       }
       EOS
 
@@ -17,37 +16,15 @@ describe 'gitlab class' do
       apply_manifest(pp, :catch_changes  => true)
     end
 
-    it 'should run reconfigure when config changes' do
-
-      # gitlab-omnibus works differently in docker
-      # Requires manual kick for beaker docker tests
-      docker_workaround = <<-EOS
-      exec { '/opt/gitlab/embedded/bin/runsvdir-start &':
-        onlyif => '/bin/cat /proc/self/cgroup | grep docker'
-      }
-      EOS
-
-      apply_manifest(docker_workaround, :catch_failures => true)
-
-      start_service_pp = <<-EOS
-      class { 'gitlab':
-        external_url   => "http://${::fqdn}",
-        gitlab_rails   => { 'time_zone' => 'GMT' }
-      }
-      EOS
-
-      apply_manifest(start_service_pp, :catch_failures => true, :show_diff => true) do |r|
-        expect(r.stdout).to match(/Scheduling refresh of Exec\[gitlab_reconfigure\]/)
-      end
-    end
-
     describe package('gitlab-ce') do
       it { is_expected.to be_installed }
     end
 
-    context 'allows http connection on port 80' do
+
+    it 'allows http connection on port 8080' do
+      shell 'sleep 15' # give it some time to start up
       describe command('curl 0.0.0.0:80/users/sign_in') do
-        its(:stdout) { should match /reset_password_token|GitLab/ }
+        its(:stdout) { should match /GitLab|password/ }
       end
     end
 

--- a/spec/acceptance/travis_ci_acceptance_spec.rb
+++ b/spec/acceptance/travis_ci_acceptance_spec.rb
@@ -1,0 +1,77 @@
+require 'spec_helper_acceptance'
+
+describe 'gitlab class' do
+
+  context 'travis specific docker tests' do
+    # Using puppet_apply as a helper
+    it 'should work idempotently with no errors' do
+      pp = <<-EOS
+      class { 'gitlab':
+        external_url   => "http://${::fqdn}",
+        service_manage => false,
+      }
+      EOS
+
+      # Run it twice and test for idempotency
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes  => true)
+    end
+
+    it 'should run reconfigure when config changes' do
+
+      # gitlab-omnibus works differently in docker
+      # Requires manual kick for travis beaker docker tests
+      docker_workaround = <<-EOS
+      exec { '/opt/gitlab/embedded/bin/runsvdir-start &':
+        onlyif => '/bin/cat /proc/self/cgroup | grep docker'
+      }
+      EOS
+
+      apply_manifest(docker_workaround, :catch_failures => true)
+
+      start_service_pp = <<-EOS
+      class { 'gitlab':
+        external_url   => "http://${::fqdn}",
+        gitlab_rails   => { 'time_zone' => 'GMT' }
+      }
+      EOS
+
+      apply_manifest(start_service_pp, :catch_failures => true, :show_diff => true) do |r|
+        expect(r.stdout).to match(/Scheduling refresh of Exec\[gitlab_reconfigure\]/)
+      end
+    end
+
+    describe package('gitlab-ce') do
+      it { is_expected.to be_installed }
+    end
+
+    context 'allows http connection on port 80' do
+      describe command('curl 0.0.0.0:80/users/sign_in') do
+        its(:stdout) { should match /reset_password_token|GitLab/ }
+      end
+    end
+  end
+
+  describe 'gitlab::cirunner class' do
+
+    context 'basic parameters without docker' do
+
+    it 'should work idempotently with no errors' do
+      pp = <<-EOS
+      class { 'gitlab::cirunner':
+        manage_docker => false, # Running docker in docker in travis breaks things
+      }
+      EOS
+
+      # Run it twice and test for idempotency
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes  => true)
+    end
+
+    describe package('gitlab-ci-multi-runner') do
+      it { is_expected.to be_installed }
+    end
+  end
+end
+
+end


### PR DESCRIPTION
* There are issues running docker in docker in Travis, so lets test the easiest use-case
* Adds a specific Travis spec with the docker workarounds required
* Revert the class spec so tests in Vagrant can still work outside of Travis