### PR TITLE
External url

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ the `$::os` fact used in `install.pp` doesn't work as expected.
 
 ### Beginning with Gitlab
 
-Just include the class and specify at least `external_url`.
+Just include the class and specify at least `external_url`. If `external_url` is not specified it will default to the FQDN fact of the system. 
 
 ```puppet
 class { 'gitlab':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -103,7 +103,7 @@
 #   Hash of 'ci_unicorn' config parameters.
 #
 # [*external_url*]
-#   Default: undef
+#   Default: http://$fqdn
 #   External URL of Gitlab.
 #
 # [*external_port*]
@@ -296,7 +296,7 @@ class gitlab (
   $ci_unicorn = undef,
   $config_manage = $::gitlab::params::config_manage,
   $config_file = $::gitlab::params::config_file,
-  $external_url = undef,
+  $external_url = $::gitlab::params::external_url,
   $external_port = undef,
   $git = undef,
   $git_data_dir = undef,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -39,7 +39,7 @@ class gitlab::params {
   }
 
   # gitlab specific
-  $external_url = "http://${fqdn}"
+  $external_url = "http://${::fqdn}"
   $config_manage = true
   $config_file = '/etc/gitlab/gitlab.rb'
   $secrets_file = '/etc/gitlab/gitlab-secrets.json'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -39,6 +39,7 @@ class gitlab::params {
   }
 
   # gitlab specific
+  $external_url = "http://${fqdn}"
   $config_manage = true
   $config_file = '/etc/gitlab/gitlab.rb'
   $secrets_file = '/etc/gitlab/gitlab-secrets.json'


### PR DESCRIPTION
The external_url variable is the only variable that is mandatory for gitlab to install properly. Therefore at it should not have an undef default value. This allows the class to be compiled without a value that will cause the install to fail. 

This PR sets a default value for `external_url` to http://$fqdn. This replaces the undef default value with a the fqdn fact of the node. 