### PR TITLE
Fix incorrect syntax in "gitlab_rails['ldap_servers']" field

### DIFF
--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -235,7 +235,7 @@ describe 'gitlab' do
 
       it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') \
         .with_content(/^\s*gitlab_rails\['ldap_enabled'\] = true$/)
-        .with_content(/^\s*gitlab_rails\['ldap_servers'\] = {\"main\"=>{\"active_directory\"=>true, \"allow_username_or_email_login\"=>false, \"base\"=>\"\", \"bind_dn\"=>\"_the_full_dn_of_the_user_you_will_bind_with\", \"block_auto_created_users\"=>false, \"host\"=>\"_your_ldap_server\", \"label\"=>\"LDAP\", \"method\"=>\"plain\", \"password\"=>\"_the_password_of_the_bind_user\", \"port\"=>(")?389(")?, \"uid\"=>\"sAMAccountName\", \"user_filter\"=>\"\"}}$/)
+        .with_content(/^\s*gitlab_rails\['ldap_servers'\] = YAML.load <<-EOS\n  main:\n    label: LDAP\n    host: \"_your_ldap_server\"\n    port: \"389\"\n    uid: sAMAccountName\n    method: plain\n    bind_dn: \"_the_full_dn_of_the_user_you_will_bind_with\"\n    password: \"_the_password_of_the_bind_user\"\n    active_directory: true\n    allow_username_or_email_login: false\n    block_auto_created_users: false\n    base: \"\"\n    user_filter: \"\"\nEOS\n/m)
         .with_content(/^\s*gitlab_rails\['omniauth_providers'\] = \[{\"app_id\"=>\"YOUR APP ID\", \"app_secret\"=>\"YOUR APP SECRET\", \"args\"=>{\"access_type\"=>\"offline\", \"approval_prompt\"=>\"\"}, \"name\"=>\"google_oauth2\"}\]$/)
       }
     end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -235,7 +235,7 @@ describe 'gitlab' do
 
       it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') \
         .with_content(/^\s*gitlab_rails\['ldap_enabled'\] = true$/)
-        .with_content(/^\s*gitlab_rails\['ldap_servers'\] = YAML.load <<-EOS\n  main:\n    label: LDAP\n    host: \"_your_ldap_server\"\n    port: \"389\"\n    uid: sAMAccountName\n    method: plain\n    bind_dn: \"_the_full_dn_of_the_user_you_will_bind_with\"\n    password: \"_the_password_of_the_bind_user\"\n    active_directory: true\n    allow_username_or_email_login: false\n    block_auto_created_users: false\n    base: \"\"\n    user_filter: \"\"\nEOS\n/m)
+        .with_content(/^\s*gitlab_rails\['ldap_servers'\] = YAML.load <<-EOS\n  main:\n    label: LDAP\n    host: \"_your_ldap_server\"\n    port: \"?389\"?\n    uid: sAMAccountName\n    method: plain\n    bind_dn: \"_the_full_dn_of_the_user_you_will_bind_with\"\n    password: \"_the_password_of_the_bind_user\"\n    active_directory: true\n    allow_username_or_email_login: false\n    block_auto_created_users: false\n    base: \"\"\n    user_filter: \"\"\nEOS\n/m)
         .with_content(/^\s*gitlab_rails\['omniauth_providers'\] = \[{\"app_id\"=>\"YOUR APP ID\", \"app_secret\"=>\"YOUR APP SECRET\", \"args\"=>{\"access_type\"=>\"offline\", \"approval_prompt\"=>\"\"}, \"name\"=>\"google_oauth2\"}\]$/)
       }
     end

--- a/templates/gitlab.rb.erb
+++ b/templates/gitlab.rb.erb
@@ -52,8 +52,13 @@ git_data_dir "<%= @git_data_dir %>"
 ############################
 
 <%- @gitlab_rails.keys.sort.each do |k| -%>
+<%- if k == 'ldap_servers' -%>
+gitlab_rails['<%= k -%>'] = YAML.load <<-EOS
+<%= @gitlab_rails[k].to_yaml.gsub(/\s+$/,'').gsub(/---\s*\n/,'') %>
+EOS
+<%- else -%>
 gitlab_rails['<%= k -%>'] = <%= decorate(@gitlab_rails[k]) %>
-<%- end end -%>
+<%- end end end -%>
 <%- if @user -%>
 
 ###############


### PR DESCRIPTION
In reference to issue #92.

It appears that no matter how a hash is presented to GitLab, it will not accept it. The field must be presented as YAML, at least in the version I tested.

- The "gitlab_rails['ldap_servers']" field is presented as YAML instead of a hash. In my testing the "to_yaml" call used in the template always produced valid YAML that GitLab accepted.
- Updated the Rspec Test.
- Tested on GitLab 8.13.3, rev 8d79ab3 on CentOS 7