### PR TITLE
Fix #82

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ spec/fixtures
 
 log/
 junit/
+
+.ruby-version

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -18,7 +18,7 @@ class gitlab::install {
         include apt
         ensure_packages('apt-transport-https')
         $_lower_os = downcase($::operatingsystem)
-        apt::source { 'gitlab_official':
+        apt::source { "gitlab_official_${edition}":
           comment  => 'Official repository for Gitlab',
           location => "https://packages.gitlab.com/gitlab/gitlab-${edition}/${_lower_os}/",
           release  => $::lsbdistcodename,
@@ -37,7 +37,7 @@ class gitlab::install {
             ensure  => $package_ensure,
             require => [
               Exec['apt_update'],
-              Apt::Source['gitlab_official'],
+              Apt::Source["gitlab_official_${edition}"],
             ],
           }
         }
@@ -56,7 +56,7 @@ class gitlab::install {
           $releasever = $::operatingsystemmajrelease
         }
 
-        yumrepo { 'gitlab_official':
+        yumrepo { "gitlab_official_${edition}":
           descr         => 'Official repository for Gitlab',
           baseurl       => "https://packages.gitlab.com/gitlab/gitlab-${edition}/el/${releasever}/\$basearch",
           enabled       => 1,
@@ -70,7 +70,7 @@ class gitlab::install {
         if $manage_package {
           package { $package_name:
             ensure  => $package_ensure,
-            require => Yumrepo['gitlab_official'],
+            require => Yumrepo["gitlab_official_${edition}"],
           }
         }
       }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -18,7 +18,7 @@ describe 'gitlab' do
       it { is_expected.to contain_class('gitlab::install').that_comes_before('Class[gitlab::config]') }
       it { is_expected.to contain_class('gitlab::config') }
       it { is_expected.to contain_class('gitlab::service').that_subscribes_to('Class[gitlab::config]') }
-      it { is_expected.to contain_apt__source('gitlab_official') }
+      it { is_expected.to contain_apt__source('gitlab_official_ce') }
       it { is_expected.to contain_exec('gitlab_reconfigure') }
       it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') }
 
@@ -55,7 +55,7 @@ describe 'gitlab' do
       it { is_expected.to contain_class('gitlab::install').that_comes_before('Class[gitlab::config]') }
       it { is_expected.to contain_class('gitlab::config') }
       it { is_expected.to contain_class('gitlab::service').that_subscribes_to('Class[gitlab::config]') }
-      it { is_expected.to contain_yumrepo('gitlab_official') }
+      it { is_expected.to contain_yumrepo('gitlab_official_ce') }
 
       it { is_expected.to contain_service('gitlab-runsvdir') }
       it { is_expected.to contain_package('gitlab-ce').with_ensure('installed') }


### PR DESCRIPTION
This PR should fix the issue where upgrading from Gitlab CE to Gitlab EE require manual work.

Please review, may need to add additional code to remove the Repo for whichever edition is not being used.