### PR TITLE
cirunner: fix missing dependency to apt-transport-https

### DIFF
--- a/manifests/cirunner.pp
+++ b/manifests/cirunner.pp
@@ -63,6 +63,9 @@ class gitlab::cirunner (
   if $manage_repo {
     case $::osfamily {
       'Debian': {
+        include apt
+        ensure_packages('apt-transport-https')
+
         $distid = downcase($::lsbdistid)
 
         ::apt::source { 'apt_gitlabci':


### PR DESCRIPTION
fix missing dependency to apt-transport-https if cirunner is not running on gitlab host itself