### PR TITLE
fixed the use of Integers in gitlab_rails Settings inside gitlab.rb

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v.1.11.1 [2017-01-12]
+
+* Fixed gitlab.rb template for Integers in `gitlab_rails` setting because of rack_attack_git_basic_auth will fail during gitlab reconfiguration if the Integer Values are Strings. 
+
 ## v1.11.0 [2016-12-23]
 
 * Feature to manage `manage_storage_directores`. Thanks to Greg Dowmont

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "vshn-gitlab",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "author": "vshn",
   "summary": "Installation and configuration of Gitlab Omnibus",
   "license": "BSD-3-Clause",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -236,7 +236,7 @@ describe 'gitlab' do
       it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') \
         .with_content(/^\s*gitlab_rails\['ldap_enabled'\] = true$/)
         .with_content(/^\s*gitlab_rails\['ldap_servers'\] = YAML.load <<-EOS\n  main:\n    label: LDAP\n    host: \"_your_ldap_server\"\n    port: \"?389\"?\n    uid: sAMAccountName\n    method: plain\n    bind_dn: \"_the_full_dn_of_the_user_you_will_bind_with\"\n    password: \"_the_password_of_the_bind_user\"\n    active_directory: true\n    allow_username_or_email_login: false\n    block_auto_created_users: false\n    base: \"\"\n    user_filter: \"\"\nEOS\n/m)
-        .with_content(/^\s*gitlab_rails\['omniauth_providers'\] = \[{\"app_id\"=>\"YOUR APP ID\", \"app_secret\"=>\"YOUR APP SECRET\", \"args\"=>{\"access_type\"=>\"offline\", \"approval_prompt\"=>\"\"}, \"name\"=>\"google_oauth2\"}\]$/)
+        .with_content(/^\s*gitlab_rails\['omniauth_providers'\] = \[{\"name\"=>\"google_oauth2\", \"app_id\"=>\"YOUR APP ID\", \"app_secret\"=>\"YOUR APP SECRET\", \"args\"=>{\"access_type\"=>\"offline\", \"approval_prompt\"=>\"\"}}\]$/)
       }
     end
     describe 'gitlab_git_http_server with hash value' do
@@ -247,6 +247,32 @@ describe 'gitlab' do
       it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') \
         .with_content(/^\s*gitlab_git_http_server\['enable'\] = true$/)
       }
+    end
+    describe 'gitlab_rails with string value' do
+      let(:params) {{:gitlab_rails => {
+        'backup_path' => '/opt/gitlab_backup',
+      }}}
+
+      it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') \
+        .with_content(/^\s*gitlab_rails\['backup_path'\] = \'\/opt\/gitlab_backup\'$/)
+      }
+    end
+    describe 'rack_attack_git_basic_auth with Numbers and Strings' do
+      let(:params) {{
+         :gitlab_rails => {
+           'rack_attack_git_basic_auth' => {
+             'enable' => true,
+             'ip_whitelist' => ["127.0.0.1", "10.0.0.0"],
+             'maxretry' => 10,
+             'findtime' => 60,
+             'bantime' => 3600,
+           },
+         },
+       }}
+ 
+       it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') \
+         .with_content(/^\s*gitlab_rails\['rack_attack_git_basic_auth'\] = {\"bantime\"=>3600, \"enable\"=>true, \"findtime\"=>60, \"ip_whitelist\"=>\[\"127.0.0.1\", \"10.0.0.0\"\], \"maxretry\"=>10}$/)
+       }
     end
     describe 'mattermost external URL' do
       let(:params) {{:mattermost_external_url => 'https://mattermost.myserver.tld' }}

--- a/templates/gitlab.rb.erb
+++ b/templates/gitlab.rb.erb
@@ -16,6 +16,8 @@ end
 def decorate(v)
     if v =~ /\AYAML/
         return v
+    elsif v =~ /^[\d]+$/
+        return Integer(v)
     elsif v.is_a?(String)
         return "'#{v}'"
     elsif v.is_a?(Array)
@@ -23,9 +25,13 @@ def decorate(v)
         v.each { |elem|
             temp.push(decorate(elem))
         }
-        return "[#{temp.join(',')}]"
+        return v
     elsif v.is_a?(Hash)
-        return sort_nested_hash_inspect(v)
+        temp = {}
+        v.each { |k, val|
+            temp[k] = decorate(val)
+        }
+        return sort_nested_hash_inspect(temp)
     else
         return v
     end


### PR DESCRIPTION
Within the rack_attack_git_basic_auth settings in gitlab_rails the support of integer values is needed.
At the moment all Integers will be interpreted as Strings like this:
gitlab_rails['rack_attack_git_basic_auth'] = {"bantime"=>"3600", "enabled"=>true, "findtime"=>"60", "ip_whitelist"=>["127.0.0.1", "195.65.222.171"], "maxretry"=>"10"}

And after the Puppet run with a gitlab reconfiguration gitlab breaks with the following error, as soon as rack_attack is used:
TypeError (String can't be coerced into Fixnum):
  lib/gitlab/auth/ip_rate_limiter.rb:16:in `reset!'
  lib/gitlab/auth.rb:51:in `rate_limit!'
  lib/gitlab/auth.rb:18:in `find_for_git_client'
  app/controllers/projects/git_http_client_controller.rb:117:in `handle_basic_authentication'
  app/controllers/projects/git_http_client_controller.rb:31:in `authenticate_user'
  lib/gitlab/request_profiler/middleware.rb:15:in `call'
  lib/gitlab/middleware/go.rb:16:in `call'
  lib/gitlab/middleware/readonly_geo.rb:29:in `call'

With the Fix in gitlab.rb.erb the rack_attack_git_basic_auth settings will be interpreted correctly. 