### PR TITLE
Adds ability to specify git_data_dirs

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -16,6 +16,12 @@ class gitlab::config {
   $external_port = $::gitlab::external_port
   $git = $::gitlab::git
   $git_data_dir = $::gitlab::git_data_dir
+  # git_data_dirs is the new way to specify data_dirs, introduced in 8.10
+  if $git_data_dir {
+    $git_data_dirs = { 'default' => $::gitlab::git_data_dir }.merge($::gitlab::git_data_dirs) 
+  } else {
+    $git_data_dirs = $::gitlab::git_data_dirs
+  }
   $gitlab_git_http_server = $::gitlab::gitlab_git_http_server
   $gitlab_ci = $::gitlab::gitlab_ci
   $gitlab_pages = $::gitlab::gitlab_pages

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -300,6 +300,7 @@ class gitlab (
   $external_port = undef,
   $git = undef,
   $git_data_dir = undef,
+  $git_data_dirs = {},
   $gitlab_git_http_server = undef,
   $gitlab_ci = undef,
   $gitlab_pages = undef,
@@ -357,6 +358,7 @@ class gitlab (
   validate_string($external_url)
   if $git  { validate_hash($git) }
   if $git_data_dir { validate_absolute_path($git_data_dir) }
+  if $git_data_dirs { validate_hash($git_data_dirs) }
   if $gitlab_git_http_server { validate_hash($gitlab_git_http_server) }
   if $gitlab_pages { validate_hash($gitlab_pages) }
   if $gitlab_workhorse { validate_hash($gitlab_workhorse) }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -270,5 +270,26 @@ describe 'gitlab' do
       it { should_not contain_package('gitlab-ce') }
       it { should_not contain_package('gitlab-ee') }
     end
+    describe 'with data_dirs' do
+      let(:params) do
+        {
+          'git_data_dirs' => {
+            'default' => '/var/opt/gitlab/data',
+            'alt' => '/opt/data'
+          }
+        }
+       end
+      it do
+        is_expected.to contain_file('/etc/gitlab/gitlab.rb')
+          .with_content(/^\s*git_data_dirs\(\{\"alt\"\=\>\"\/opt\/data\"\,\s\"default\"=>\"\/var\/opt\/gitlab\/data\"\}\)/)
+      end
+    end
+    describe 'without data_dirs' do
+      let(:params) {{:git_data_dir => '/var/opt/data' }}
+      it do
+        is_expected.to contain_file('/etc/gitlab/gitlab.rb')
+          .with_content(%r{"/var/opt/data"})
+      end
+    end
   end
 end

--- a/templates/gitlab.rb.erb
+++ b/templates/gitlab.rb.erb
@@ -39,12 +39,20 @@ external_url '<%= @external_url %>'
 external_port '<%= @external_port %>'
 <%- end -%>
 <%- if @git_data_dir -%>
-
 ## For setting up different data storing directory
 ## see https://gitlab.com/gitlab-org/omnibus-gitlab/blob/629def0a7a26e7c2326566f0758d4a27857b52a3/README.md#storing-git-data-in-an-alternative-directory
 ## If you want to use a single non-default directory to store git data use:
 git_data_dir "<%= @git_data_dir %>"
 <%- end -%>
+
+<%- if @git_data_dirs -%>
+### For setting up different data storing directory
+###! Docs: https://docs.gitlab.com/omnibus/settings/configuration.html#storing-git-data-in-an-alternative-directory
+###! **If you want to use a single non-default directory to store git data use a
+###!   path that doesn't contain symlinks.**
+git_data_dirs(<%= decorate(@git_data_dirs) %>)
+<%- end -%>
+
 <%- if @gitlab_rails -%>
 
 ############################


### PR DESCRIPTION
  * previously if you wanted to specify a data directory you would use
    git_data_dir.  However this setting was deprecated in 8.10 in favor
    of git_data_dirs which is a hash of multiple directories.

  * This adds git_data_dirs to the gitlab.rb template and populates
    the hash with the legacy git_data_dir if used, as well as also
    adding the legacy setting.