### PR TITLE
fixed method for sorting hashes in gitlab.rb to sort ldap hashes too

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## v.1.11.2 [2017-02-09]
+* Fixed Sorted Hash method in gitlab.rb template to sort ldap hash too
+
+## v.1.11.1 [2017-01-12]
+
+* Fixed gitlab.rb template for Integers in `gitlab_rails` setting because of rack_attack_git_basic_auth will fail during gitlab reconfiguration if the Integer Values are Strings.
+
 ## v1.11.0 [2016-12-23]
 
 * Feature to manage `manage_storage_directores`. Thanks to Greg Dowmont
@@ -10,13 +17,6 @@
 * `external_url` now defaults to `http://$fqdn`. Thanks to @willonit
 * Fixes to gitlab.rb template for `gitlab_rails` setting. Thanks to John Nicholas
 * Small fix for easier upgrading from ce to ee. Thanks to @dhollinger
-
-## v.1.11.2 [2017-02-09]
-* Fixed Sorted Hash method in gitlab.rb template to sort ldap hash too
-
-## v.1.11.0 [2017-01-12]
-
-* Fixed gitlab.rb template for Integers in `gitlab_rails` setting because of rack_attack_git_basic_auth will fail during gitlab reconfiguration if the Integer Values are Strings. 
 
 ## v1.10.0 [2016-08-10]
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,13 @@
 * Fixes to gitlab.rb template for `gitlab_rails` setting. Thanks to John Nicholas
 * Small fix for easier upgrading from ce to ee. Thanks to @dhollinger
 
+## v.1.11.2 [2017-02-09]
+* Fixed Sorted Hash method in gitlab.rb template to sort ldap hash too
+
+## v.1.11.0 [2017-01-12]
+
+* Fixed gitlab.rb template for Integers in `gitlab_rails` setting because of rack_attack_git_basic_auth will fail during gitlab reconfiguration if the Integer Values are Strings. 
+
 ## v1.10.0 [2016-08-10]
 
 * Several small fixes

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "vshn-gitlab",
-  "version": "1.11.0",
+  "version": "1.11.2",
   "author": "vshn",
   "summary": "Installation and configuration of Gitlab Omnibus",
   "license": "BSD-3-Clause",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -235,8 +235,8 @@ describe 'gitlab' do
 
       it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') \
         .with_content(/^\s*gitlab_rails\['ldap_enabled'\] = true$/)
-        .with_content(/^\s*gitlab_rails\['ldap_servers'\] = YAML.load <<-EOS\n  main:\n    label: LDAP\n    host: \"_your_ldap_server\"\n    port: \"?389\"?\n    uid: sAMAccountName\n    method: plain\n    bind_dn: \"_the_full_dn_of_the_user_you_will_bind_with\"\n    password: \"_the_password_of_the_bind_user\"\n    active_directory: true\n    allow_username_or_email_login: false\n    block_auto_created_users: false\n    base: \"\"\n    user_filter: \"\"\nEOS\n/m)
-        .with_content(/^\s*gitlab_rails\['omniauth_providers'\] = \[{\"app_id\"=>\"YOUR APP ID\", \"app_secret\"=>\"YOUR APP SECRET\", \"args\"=>{\"access_type\"=>\"offline\", \"approval_prompt\"=>\"\"}, \"name\"=>\"google_oauth2\"}\]$/)
+        .with_content(/^\s*gitlab_rails\['ldap_servers'\] = YAML.load <<-EOS\n  main:\n    active_directory: true\n    allow_username_or_email_login: false\n    base: \"\"\n    bind_dn: \"_the_full_dn_of_the_user_you_will_bind_with\"\n    block_auto_created_users: false\n    host: \"_your_ldap_server\"\n    label: LDAP\n    method: plain\n    password: \"_the_password_of_the_bind_user\"\n    port: \"?389\"?\n    uid: sAMAccountName\n    user_filter: \"\"\nEOS\n/m)
+        .with_content(/^\s*gitlab_rails\['omniauth_providers'\] = \[{\"name\"=>\"google_oauth2\", \"app_id\"=>\"YOUR APP ID\", \"app_secret\"=>\"YOUR APP SECRET\", \"args\"=>{\"access_type\"=>\"offline\", \"approval_prompt\"=>\"\"}}\]$/)
       }
     end
     describe 'gitlab_git_http_server with hash value' do
@@ -247,6 +247,23 @@ describe 'gitlab' do
       it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') \
         .with_content(/^\s*gitlab_git_http_server\['enable'\] = true$/)
       }
+    end
+    describe 'rack_attack_git_basic_auth with Numbers and Strings' do
+      let(:params) {{
+         :gitlab_rails => {
+           'rack_attack_git_basic_auth' => {
+             'enable' => true,
+             'ip_whitelist' => ["127.0.0.1", "10.0.0.0"],
+             'maxretry' => 10,
+             'findtime' => 60,
+             'bantime' => 3600,
+           },
+         },
+       }}
+ 
+       it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') \
+         .with_content(/^\s*gitlab_rails\['rack_attack_git_basic_auth'\] = {\"bantime\"=>3600, \"enable\"=>true, \"findtime\"=>60, \"ip_whitelist\"=>\[\"127.0.0.1\", \"10.0.0.0\"\], \"maxretry\"=>10}$/)
+       }
     end
     describe 'mattermost external URL' do
       let(:params) {{:mattermost_external_url => 'https://mattermost.myserver.tld' }}

--- a/templates/gitlab.rb.erb
+++ b/templates/gitlab.rb.erb
@@ -5,17 +5,24 @@
 # As this template is writing a config file based on some hashes and hashes are not meant to be in a certain order,
 # We need to ensure that the order of the keys are always outputed in the same order.
 # Otherwise puppet will always update(change) the config file.
-def sort_nested_hash_inspect(h)
-    if h.class.name == 'Hash'
-        "{" + h.sort.map{|key, value| "\"#{key}\"=>#{sort_nested_hash_inspect(value)}"}.join(", ") + "}"
-    else
-        h.inspect
+
+def sort_hash_by_key(hash, deep=true, &block)
+  if hash.kind_of?(Hash)
+    hash.keys.sort(&block).reduce({}) do |memo, key|
+      memo[key] = hash[key]
+      if deep && memo[key].kind_of?(Hash)
+        memo[key] = sort_hash_by_key(memo[key], true, &block)
+      end
+      memo
     end
+  end
 end
 
 def decorate(v)
     if v =~ /\AYAML/
         return v
+    elsif v =~ /^[\d]+$/
+        return Integer(v)
     elsif v.is_a?(String)
         return "'#{v}'"
     elsif v.is_a?(Array)
@@ -23,13 +30,18 @@ def decorate(v)
         v.each { |elem|
             temp.push(decorate(elem))
         }
-        return "[#{temp.join(',')}]"
+        return v
     elsif v.is_a?(Hash)
-        return sort_nested_hash_inspect(v)
+        temp = {}
+        v.each { |k, val|
+            temp[k] = decorate(val)
+        }
+        return sort_hash_by_key(temp)
     else
         return v
     end
-end -%>
+end
+-%>
 
 ## Url on which GitLab will be reachable.
 ## For more details on configuring external_url see:
@@ -51,11 +63,13 @@ git_data_dir "<%= @git_data_dir %>"
 # gitlab.yml configuration #
 ############################
 
+
 <%- @gitlab_rails.keys.sort.each do |k| -%>
 <%- if k == 'ldap_servers' -%>
 gitlab_rails['<%= k -%>'] = YAML.load <<-EOS
-<%= @gitlab_rails[k].to_yaml.gsub(/\s+$/,'').gsub(/---\s*\n/,'') %>
+<%= sort_hash_by_key(@gitlab_rails[k]).to_yaml.gsub(/\s+$/,'').gsub(/---\s*\n/,'') %>
 EOS
+
 <%- else -%>
 gitlab_rails['<%= k -%>'] = <%= decorate(@gitlab_rails[k]) %>
 <%- end end end -%>


### PR DESCRIPTION
Fixed Method for sorting the hashes, so that the ldap hash can be sorted too. If the order of the hash elements in ldap changes at every puppet run, every time a reconfigure and a restart of the gitlab will be triggered. 