### PR TITLE
Add prometheus support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,6 @@ group :test do
   gem 'rubocop', '0.33.0'
   gem 'simplecov', '>= 0.11.0'
   gem 'simplecov-console'
-  gem 'xmlrpc'
 
   gem "puppet-lint-absolute_classname-check"
   gem "puppet-lint-leading_zero-check"

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ group :test do
   gem 'rubocop', '0.33.0'
   gem 'simplecov', '>= 0.11.0'
   gem 'simplecov-console'
+  gem 'xmlrpc'
 
   gem "puppet-lint-absolute_classname-check"
   gem "puppet-lint-leading_zero-check"

--- a/README.md
+++ b/README.md
@@ -173,6 +173,14 @@ gitlab::prometheus:
   enable: true
 ```
 
+If you are using Gitlab 8.17, you can change the listening address with:
+
+```yaml
+gitlab::prometheus:
+  enable: true
+  listen_address: 'localhost:9091'
+```
+
 ### Gitlab CI Runner Config
 
 Here is an example how to configure Gitlab CI runners using Hiera:

--- a/README.md
+++ b/README.md
@@ -164,6 +164,15 @@ gitlab::gitlab_rails:
       user_filter: ''
 ```
 
+### Enable Gitlab Embedded Prometheus
+
+Currently there is not a lot to be done here, as Gitlab pretty much only support on or off (default). To do with Hiera:
+
+```yaml
+gitlab::prometheus:
+  enable: true
+```
+
 ### Gitlab CI Runner Config
 
 Here is an example how to configure Gitlab CI runners using Hiera:

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -33,6 +33,7 @@ class gitlab::config {
   $pages_external_url = $::gitlab::pages_external_url
   $pages_nginx = $::gitlab::pages_nginx
   $pages_nginx_eq_nginx = $::gitlab::pages_nginx_eq_nginx
+  $prometheus = $::gitlab::prometheus
   $postgresql = $::gitlab::postgresql
   $redis = $::gitlab::redis
   $registry = $::gitlab::registry

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -318,6 +318,7 @@ class gitlab (
   $pages_nginx = undef,
   $pages_nginx_eq_nginx = false,
   $postgresql = undef,
+  $prometheus = undef,
   $redis = undef,
   $registry = undef,
   $registry_external_url = undef,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -264,6 +264,15 @@ describe 'gitlab' do
         .with_content(/^\s*mattermost\['enable'\] = true$/)
       }
     end
+    describe 'prometheus with hash value' do
+      let(:params) {{:prometheus => {
+        'enable' => true,
+      }}}
+
+      it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') \
+        .with_content(/^\s*prometheus\['enable'\] = true$/)
+      }
+    end
     describe 'with manage_package => false' do
       let(:params) {{:manage_package => false }}
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -273,6 +273,15 @@ describe 'gitlab' do
         .with_content(/^\s*prometheus\['enable'\] = true$/)
       }
     end
+    describe 'prometheus with hash value change listen address' do
+      let(:params) {{:prometheus => {
+        'listen_address' => 'localhost:9091',
+      }}}
+
+      it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') \
+        .with_content(/^\s*prometheus\['listen_address'\] = 'localhost:9091'$/)
+      }
+    end
     describe 'with manage_package => false' do
       let(:params) {{:manage_package => false }}
 

--- a/templates/gitlab.rb.erb
+++ b/templates/gitlab.rb.erb
@@ -352,3 +352,12 @@ registry_nginx['<%= k -%>'] = <%= decorate(@_real_registry_nginx[k]) %>
 <%- @manage_accounts.keys.sort.each do |k| -%>
 manage_accounts['<%= k -%>'] = <%= decorate(@manage_accounts[k]) %>
 <%- end end -%>
+<%- if @prometheus -%>
+##############
+# Prometheus #
+##############
+## see: https://docs.gitlab.com/ce/administration/monitoring/prometheus/index.html
+
+<%- @prometheus.keys.sort.each do |k| -%>
+prometheus['<%= k -%>'] = <%= decorate(@prometheus[k]) %>
+<%- end end -%>


### PR DESCRIPTION
Added a parameter, spec test and simple docs to enable the embedded Prometheus server that was added in Gitlab 8.16