### PR TITLE
Do not decorate within hash, this leads to doubled quotes

### DIFF
--- a/templates/gitlab.rb.erb
+++ b/templates/gitlab.rb.erb
@@ -34,7 +34,7 @@ def decorate(v)
     elsif v.is_a?(Hash)
         temp = {}
         v.each { |k, val|
-            temp[k] = decorate(val)
+            temp[k] = val
         }
         return sort_hash_by_key(temp)
     else


### PR DESCRIPTION
When we decorate within a hash, this leads to doubled quoting, i.e.

```
gitlab_ci['gitlab_server'] = {"app_id"=>"'xxxyyy'", "app_secret"=>"'zzzvvv'", "url"=>"'https://git.example.net'"}
```