### PR TITLE
Refactor unit tests to iterate over all supported OS's

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+; This file is for unifying the coding style for different editors and IDEs.
+; Plugins are available for notepad++, emacs, vim, gedit,
+; textmate, visual studio, and more.
+;
+; See http://editorconfig.org for details.
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,12 +28,6 @@
 #   Default: true
 #   Run the system service on boot.
 #
-# [*service_initd_ensure*]
-#   Default for systemd systems, as determined by the $::gitlab_systemd fact: "absent"
-#   Else: "link"
-#   Sets "ensure => 'absent'" or "ensure => 'link'" on init.d softlink
-#   depending on the $::gitlab_systemd fact to avoid conflicts with systemd.
-#
 # [*service_exec*]
 #   Default: '/usr/bin/gitlab-ctl'
 #   The service executable path.
@@ -63,12 +57,6 @@
 # [*service_hasstatus/_hasrestart*]
 #   Default: true
 #   The gitlab service has this commands available.
-#
-# [*service_provider*]
-#   Default: base
-#   The provider Puppet will use to start the service
-#   Since gitlab-ctl is a supervisor process, we use base and run
-#   the commands via runsvdir
 #
 # [*edition*]
 #   Default: ce
@@ -299,7 +287,6 @@ class gitlab (
   $package_pin = $::gitlab::params::package_pin,
   # system service configuration
   $service_enable = $::gitlab::params::service_enable,
-  $service_initd_ensure = $::gitlab::params::service_initd_ensure,
   $service_ensure = $::gitlab::params::service_ensure,
   $service_group = $::gitlab::params::service_group,
   $service_hasrestart = $::gitlab::params::service_hasrestart,
@@ -312,7 +299,6 @@ class gitlab (
   $service_status = $::gitlab::params::service_status,
   $service_stop = $::gitlab::params::service_stop,
   $service_user = $::gitlab::params::service_user,
-  $service_provider = $::gitlab::params::service_provider,
   # gitlab specific
   $edition = 'ce',
   $ci_redis = undef,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -50,15 +50,10 @@ class gitlab::install {
         }
       }
       'redhat': {
-        if is_hash($::os) {
-          $releasever = $::os[release][major]
-        } else {
-          $releasever = $::operatingsystemmajrelease
-        }
 
         yumrepo { "gitlab_official_${edition}":
           descr         => 'Official repository for Gitlab',
-          baseurl       => "https://packages.gitlab.com/gitlab/gitlab-${edition}/el/${releasever}/\$basearch",
+          baseurl       => "https://packages.gitlab.com/gitlab/gitlab-${edition}/el/\$releasever/\$basearch",
           enabled       => 1,
           gpgcheck      => 0,
           gpgkey        => 'https://packages.gitlab.com/gpg.key',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,18 +24,11 @@ class gitlab::params {
   $service_name = 'gitlab-runsvdir'
   $service_user = 'root'
   $service_group = 'root'
-  $service_provider = 'base'
 
   if $::osfamily == 'RedHat' and $::operatingsystemmajrelease == '6' {
     $service_enable = false
   } else {
     $service_enable = true
-  }
-
-  if ($::gitlab_systemd) {
-    $service_initd_ensure = 'absent'
-  } else {
-    $service_initd_ensure = 'link'
   }
 
   # gitlab specific

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -5,10 +5,6 @@
 #
 class gitlab::service {
   if $::gitlab::service_manage {
-    file { "/etc/init.d/${::gitlab::service_name}":
-      ensure => $::gitlab::service_initd_ensure,
-      target => $::gitlab::service_exec,
-    } ->
     service { $::gitlab::service_name:
       ensure     => $::gitlab::service_ensure,
       enable     => $::gitlab::service_enable,
@@ -18,7 +14,6 @@ class gitlab::service {
       status     => $::gitlab::service_status,
       hasstatus  => $::gitlab::service_hasstatus,
       hasrestart => $::gitlab::service_hasrestart,
-      provider   => $::gitlab::service_provider,
     }
   }
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,195 +1,195 @@
 require 'spec_helper'
 
 describe 'gitlab', :type => :class do
-	on_supported_os.each do |os,facts|
-		context "on #{os}" do
-			let(:facts) do
-				facts
-			end
-			
-			context "with default params" do
-      	it { is_expected.to contain_class('gitlab::params') }
-      	it { is_expected.to contain_class('gitlab::install').that_comes_before('Class[gitlab::config]') }
-      	it { is_expected.to contain_class('gitlab::config') }
-      	it { is_expected.to contain_class('gitlab::service').that_subscribes_to('Class[gitlab::config]') }
-      	it { is_expected.to contain_exec('gitlab_reconfigure') }
-      	it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') }
-      	it { is_expected.to contain_service('gitlab-runsvdir') }
-      	it { is_expected.to contain_package('gitlab-ce').with_ensure('installed') }
-      	it { is_expected.to contain_class('gitlab') }
+  on_supported_os.each do |os,facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts
+      end
+      
+      context "with default params" do
+        it { is_expected.to contain_class('gitlab::params') }
+        it { is_expected.to contain_class('gitlab::install').that_comes_before('Class[gitlab::config]') }
+        it { is_expected.to contain_class('gitlab::config') }
+        it { is_expected.to contain_class('gitlab::service').that_subscribes_to('Class[gitlab::config]') }
+        it { is_expected.to contain_exec('gitlab_reconfigure') }
+        it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') }
+        it { is_expected.to contain_service('gitlab-runsvdir') }
+        it { is_expected.to contain_package('gitlab-ce').with_ensure('installed') }
+        it { is_expected.to contain_class('gitlab') }
 
-				case facts[:osfamily]
-				when 'Debian'
-      		it { is_expected.to contain_apt__source('gitlab_official_ce') }
-				when 'RedHat'
-      		it { is_expected.to contain_yumrepo('gitlab_official_ce') }
-				end
+        case facts[:osfamily]
+        when 'Debian'
+          it { is_expected.to contain_apt__source('gitlab_official_ce') }
+        when 'RedHat'
+          it { is_expected.to contain_yumrepo('gitlab_official_ce') }
+        end
 
-				if ! facts[:gitlab_systemd]
-					it { is_expected.to contain_file('/etc/init.d/gitlab-runsvdir').with_ensure('link') }
-				else
-					it { is_expected.to contain_file('/etc/init.d/gitlab-runsvdir').with_ensure('absent') }
-				end
-			end
+        if ! facts[:gitlab_systemd]
+          it { is_expected.to contain_file('/etc/init.d/gitlab-runsvdir').with_ensure('link') }
+        else
+          it { is_expected.to contain_file('/etc/init.d/gitlab-runsvdir').with_ensure('absent') }
+        end
+      end
 
-			context "with custom facts" do
+      context "with custom facts" do
 
-			end
-			context "with class specific parameters" do
-    		describe 'edition = ee' do
-      		let(:params) { {:edition => 'ee'} }
-      		it { is_expected.to contain_package('gitlab-ee').with_ensure('installed') }
+      end
+      context "with class specific parameters" do
+        describe 'edition = ee' do
+          let(:params) { {:edition => 'ee'} }
+          it { is_expected.to contain_package('gitlab-ee').with_ensure('installed') }
 
-					case facts[:osfamily]
-					when 'Debian'
-      			it { is_expected.to contain_apt__source('gitlab_official_ee') }
-					when 'RedHat'
-      			it { is_expected.to contain_yumrepo('gitlab_official_ee') }
-					end
-    		end
-			  describe 'external_url' do
-      		let(:params) { {:external_url => 'http://gitlab.mycompany.com/'} }
-      		it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') \
-        		.with_content(/^\s*external_url 'http:\/\/gitlab\.mycompany\.com\/'$/)
-      		}
-    		end
-    		describe 'external_port' do
-      		let(:params) { {:external_port => 987654} }
-      		it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') \
-        		.with_content(/^\s*external_port '987654'$/)
-      		}
-    		end
-    		describe 'nginx' do
-      		let(:params) { {:nginx => {
-        		'enable' => true,
-        		'listen_port' => 80,
-        		}
-      		}}
-      		it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') \
-        		.with_content(/^\s*nginx\['enable'\] = true$/)
-        		.with_content(/^\s*nginx\['listen_port'\] = ('|)80('|)$/)
-      		}
-    		end	
-				describe 'secrets' do
-      		let(:params) { {:secrets => {
-        		'gitlab_shell' => {
-          		'secret_token' => 'mysupersecrettoken1',
-        		},
-        		'gitlab_rails' => {
-          		'secret_token' => 'mysupersecrettoken2',
-        		},
-        		'gitlab_ci' => {
-          		'secret_token' => 'null',
-          		'secret_key_base' => 'mysupersecrettoken3',
-          		'db_key_base' => 'mysupersecrettoken4',
-        		},
-      		}}}
-      		it { is_expected.to contain_file('/etc/gitlab/gitlab-secrets.json') \
-        		.with_content(/{\n  \"gitlab_shell\": {\n    \"secret_token\": \"mysupersecrettoken1\"\n  },\n  \"gitlab_rails\": {\n    \"secret_token\": \"mysupersecrettoken2\"\n  },\n  \"gitlab_ci\": {\n    \"secret_token\": \"null\",\n    \"secret_key_base\": \"mysupersecrettoken3\",\n    \"db_key_base\": \"mysupersecrettoken4\"\n  }\n}\n/m)
-      		}
-    		end
-				describe 'gitlab_rails with hash value' do
-      		let(:params) { {:gitlab_rails => {
-        		'ldap_enabled' => true,
-        		'ldap_servers' => {
-          		'main' => {
-            		'label' => 'LDAP',
-            		'host' => '_your_ldap_server',
-            		'port' => 389,
-            		'uid' => 'sAMAccountName',
-            		'method' => 'plain',
-            		'bind_dn' => '_the_full_dn_of_the_user_you_will_bind_with',
-            		'password' => '_the_password_of_the_bind_user',
-            		'active_directory' => true,
-            		'allow_username_or_email_login' => false,
-            		'block_auto_created_users' => false,
-            		'base' => '',
-            		'user_filter' => '',
-          		}
-        		},
-        		'omniauth_providers' => [
-          		{
-            		'name' => 'google_oauth2',
-            		'app_id' => 'YOUR APP ID',
-            		'app_secret' => 'YOUR APP SECRET',
-            		'args' => { 'access_type' => 'offline', 'approval_prompt' => '' }
-          		}
-        		]
-      		}}}
-      		let(:expected_content){ {
-        		:gitlab_rb__ldap_servers => %Q{gitlab_rails['ldap_servers'] = {\"main\"=>{\"active_directory\"=>true, \"allow_username_or_email_login\"=>false, \"base\"=>\"\", \"bind_dn\"=>\"_the_full_dn_of_the_user_you_will_bind_with\", \"block_auto_created_users\"=>false, \"host\"=>\"_your_ldap_server\", \"label\"=>\"LDAP\", \"method\"=>\"plain\", \"password\"=>\"_the_password_of_the_bind_user\", \"port\"=>389, \"uid\"=>\"sAMAccountName\", \"user_filter\"=>\"\"}}\n}
-      		}}
-      		it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') \
-        		.with_content(/^\s*gitlab_rails\['ldap_enabled'\] = true$/)
-        		.with_content( /\s*#{Regexp.quote(expected_content[:gitlab_rb__ldap_servers])}/m )
-        		.with_content(/^\s*gitlab_rails\['omniauth_providers'\] = \[{\"app_id\"=>\"YOUR APP ID\", \"app_secret\"=>\"YOUR APP SECRET\", \"args\"=>{\"access_type\"=>\"offline\", \"approval_prompt\"=>\"\"}, \"name\"=>\"google_oauth2\"}\]$/)
-      		}
-    		end	
-				describe 'gitlab_git_http_server with hash value' do
-      		let(:params) {{:gitlab_git_http_server => {
-        		'enable' => true,
-      		}}}
-      		it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') \
-        		.with_content(/^\s*gitlab_git_http_server\['enable'\] = true$/)
-      		}
-    		end
-    		describe 'gitlab_rails with string value' do
-      		let(:params) {{:gitlab_rails => {
-        		'backup_path' => '/opt/gitlab_backup',
-      		}}}
-      		it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') \
-        		.with_content(/^\s*gitlab_rails\['backup_path'\] = "\/opt\/gitlab_backup"$/)
-      		}
-    		end
-    		describe 'rack_attack_git_basic_auth with Numbers and Strings' do
-      		let(:params) {{
-         		:gitlab_rails => {
-           		'rack_attack_git_basic_auth' => {
-             		'enable' => true,
-             		'ip_whitelist' => ["127.0.0.1", "10.0.0.0"],
-             		'maxretry' => 10,
-             		'findtime' => 60,
-             		'bantime' => 3600,
-           		},
-         		},
-       		}}
-       		it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') \
-         		.with_content(/^\s*gitlab_rails\['rack_attack_git_basic_auth'\] = {\"bantime\"=>3600, \"enable\"=>true, \"findtime\"=>60, \"ip_whitelist\"=>\[\"127.0.0.1\", \"10.0.0.0\"\], \"maxretry\"=>10}$/)
-       		}
-    		end
-    		describe 'mattermost external URL' do
-      		let(:params) {{:mattermost_external_url => 'https://mattermost.myserver.tld' }}
-      		it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') \
-        		.with_content(/^\s*mattermost_external_url 'https:\/\/mattermost\.myserver\.tld'$/)
-      		}
-    		end
-    		describe 'mattermost with hash value' do
-      		let(:params) {{:mattermost => {
-        		'enable' => true,
-      		}}}
-      		it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') \
-        		.with_content(/^\s*mattermost\['enable'\] = true$/)
-      		}
-    		end
-    		describe 'with manage_package => false' do
-      		let(:params) {{:manage_package => false }}
-      		it { should_not contain_package('gitlab-ce') }
-      		it { should_not contain_package('gitlab-ee') }
-    		end
-			end
-		end
-	end
+          case facts[:osfamily]
+          when 'Debian'
+            it { is_expected.to contain_apt__source('gitlab_official_ee') }
+          when 'RedHat'
+            it { is_expected.to contain_yumrepo('gitlab_official_ee') }
+          end
+        end
+        describe 'external_url' do
+          let(:params) { {:external_url => 'http://gitlab.mycompany.com/'} }
+          it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') \
+            .with_content(/^\s*external_url 'http:\/\/gitlab\.mycompany\.com\/'$/)
+          }
+        end
+        describe 'external_port' do
+          let(:params) { {:external_port => 987654} }
+          it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') \
+            .with_content(/^\s*external_port '987654'$/)
+          }
+        end
+        describe 'nginx' do
+          let(:params) { {:nginx => {
+            'enable' => true,
+            'listen_port' => 80,
+            }
+          }}
+          it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') \
+            .with_content(/^\s*nginx\['enable'\] = true$/)
+            .with_content(/^\s*nginx\['listen_port'\] = ('|)80('|)$/)
+          }
+        end 
+        describe 'secrets' do
+          let(:params) { {:secrets => {
+            'gitlab_shell' => {
+              'secret_token' => 'mysupersecrettoken1',
+            },
+            'gitlab_rails' => {
+              'secret_token' => 'mysupersecrettoken2',
+            },
+            'gitlab_ci' => {
+              'secret_token' => 'null',
+              'secret_key_base' => 'mysupersecrettoken3',
+              'db_key_base' => 'mysupersecrettoken4',
+            },
+          }}}
+          it { is_expected.to contain_file('/etc/gitlab/gitlab-secrets.json') \
+            .with_content(/{\n  \"gitlab_shell\": {\n    \"secret_token\": \"mysupersecrettoken1\"\n  },\n  \"gitlab_rails\": {\n    \"secret_token\": \"mysupersecrettoken2\"\n  },\n  \"gitlab_ci\": {\n    \"secret_token\": \"null\",\n    \"secret_key_base\": \"mysupersecrettoken3\",\n    \"db_key_base\": \"mysupersecrettoken4\"\n  }\n}\n/m)
+          }
+        end
+        describe 'gitlab_rails with hash value' do
+          let(:params) { {:gitlab_rails => {
+            'ldap_enabled' => true,
+            'ldap_servers' => {
+              'main' => {
+                'label' => 'LDAP',
+                'host' => '_your_ldap_server',
+                'port' => 389,
+                'uid' => 'sAMAccountName',
+                'method' => 'plain',
+                'bind_dn' => '_the_full_dn_of_the_user_you_will_bind_with',
+                'password' => '_the_password_of_the_bind_user',
+                'active_directory' => true,
+                'allow_username_or_email_login' => false,
+                'block_auto_created_users' => false,
+                'base' => '',
+                'user_filter' => '',
+              }
+            },
+            'omniauth_providers' => [
+              {
+                'name' => 'google_oauth2',
+                'app_id' => 'YOUR APP ID',
+                'app_secret' => 'YOUR APP SECRET',
+                'args' => { 'access_type' => 'offline', 'approval_prompt' => '' }
+              }
+            ]
+          }}}
+          let(:expected_content){ {
+            :gitlab_rb__ldap_servers => %Q{gitlab_rails['ldap_servers'] = {\"main\"=>{\"active_directory\"=>true, \"allow_username_or_email_login\"=>false, \"base\"=>\"\", \"bind_dn\"=>\"_the_full_dn_of_the_user_you_will_bind_with\", \"block_auto_created_users\"=>false, \"host\"=>\"_your_ldap_server\", \"label\"=>\"LDAP\", \"method\"=>\"plain\", \"password\"=>\"_the_password_of_the_bind_user\", \"port\"=>389, \"uid\"=>\"sAMAccountName\", \"user_filter\"=>\"\"}}\n}
+          }}
+          it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') \
+            .with_content(/^\s*gitlab_rails\['ldap_enabled'\] = true$/)
+            .with_content( /\s*#{Regexp.quote(expected_content[:gitlab_rb__ldap_servers])}/m )
+            .with_content(/^\s*gitlab_rails\['omniauth_providers'\] = \[{\"app_id\"=>\"YOUR APP ID\", \"app_secret\"=>\"YOUR APP SECRET\", \"args\"=>{\"access_type\"=>\"offline\", \"approval_prompt\"=>\"\"}, \"name\"=>\"google_oauth2\"}\]$/)
+          }
+        end 
+        describe 'gitlab_git_http_server with hash value' do
+          let(:params) {{:gitlab_git_http_server => {
+            'enable' => true,
+          }}}
+          it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') \
+            .with_content(/^\s*gitlab_git_http_server\['enable'\] = true$/)
+          }
+        end
+        describe 'gitlab_rails with string value' do
+          let(:params) {{:gitlab_rails => {
+            'backup_path' => '/opt/gitlab_backup',
+          }}}
+          it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') \
+            .with_content(/^\s*gitlab_rails\['backup_path'\] = "\/opt\/gitlab_backup"$/)
+          }
+        end
+        describe 'rack_attack_git_basic_auth with Numbers and Strings' do
+          let(:params) {{
+            :gitlab_rails => {
+              'rack_attack_git_basic_auth' => {
+                'enable' => true,
+                'ip_whitelist' => ["127.0.0.1", "10.0.0.0"],
+                'maxretry' => 10,
+                'findtime' => 60,
+                'bantime' => 3600,
+              },
+            },
+          }}
+          it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') \
+            .with_content(/^\s*gitlab_rails\['rack_attack_git_basic_auth'\] = {\"bantime\"=>3600, \"enable\"=>true, \"findtime\"=>60, \"ip_whitelist\"=>\[\"127.0.0.1\", \"10.0.0.0\"\], \"maxretry\"=>10}$/)
+          }
+        end
+        describe 'mattermost external URL' do
+          let(:params) {{:mattermost_external_url => 'https://mattermost.myserver.tld' }}
+          it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') \
+            .with_content(/^\s*mattermost_external_url 'https:\/\/mattermost\.myserver\.tld'$/)
+          }
+        end
+        describe 'mattermost with hash value' do
+          let(:params) {{:mattermost => {
+            'enable' => true,
+          }}}
+          it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') \
+            .with_content(/^\s*mattermost\['enable'\] = true$/)
+          }
+        end
+        describe 'with manage_package => false' do
+          let(:params) {{:manage_package => false }}
+          it { should_not contain_package('gitlab-ce') }
+          it { should_not contain_package('gitlab-ee') }
+        end
+      end
+    end
+  end
 
-	context "on usupported os" do
-		let(:facts) {{
-    	:gitlab_systemd  => false,
-    	:osfamily        => 'Solaris',
-    	:operatingsystem => 'Nexenta',
-		}}
+  context "on usupported os" do
+    let(:facts) {{
+      :gitlab_systemd  => false,
+      :osfamily        => 'Solaris',
+      :operatingsystem => 'Nexenta',
+    }}
 
-		describe 'gitlab class without any parameters on Solaris/Nexenta' do
+    describe 'gitlab class without any parameters on Solaris/Nexenta' do
       it { is_expected.to compile.and_raise_error(/is not supported/) }
     end
-	end
+  end
 
 end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -6,7 +6,7 @@ describe 'gitlab', :type => :class do
       let(:facts) do
         facts
       end
-      
+
       context "with default params" do
         it { is_expected.to contain_class('gitlab::params') }
         it { is_expected.to contain_class('gitlab::install').that_comes_before('Class[gitlab::config]') }
@@ -25,16 +25,8 @@ describe 'gitlab', :type => :class do
           it { is_expected.to contain_yumrepo('gitlab_official_ce') }
         end
 
-        if ! facts[:gitlab_systemd]
-          it { is_expected.to contain_file('/etc/init.d/gitlab-runsvdir').with_ensure('link') }
-        else
-          it { is_expected.to contain_file('/etc/init.d/gitlab-runsvdir').with_ensure('absent') }
-        end
       end
 
-      context "with custom facts" do
-
-      end
       context "with class specific parameters" do
         describe 'edition = ee' do
           let(:params) { {:edition => 'ee'} }
@@ -69,7 +61,7 @@ describe 'gitlab', :type => :class do
             .with_content(/^\s*nginx\['enable'\] = true$/)
             .with_content(/^\s*nginx\['listen_port'\] = ('|)80('|)$/)
           }
-        end 
+        end
         describe 'secrets' do
           let(:params) { {:secrets => {
             'gitlab_shell' => {
@@ -124,7 +116,7 @@ describe 'gitlab', :type => :class do
             .with_content( /\s*#{Regexp.quote(expected_content[:gitlab_rb__ldap_servers])}/m )
             .with_content(/^\s*gitlab_rails\['omniauth_providers'\] = \[{\"app_id\"=>\"YOUR APP ID\", \"app_secret\"=>\"YOUR APP SECRET\", \"args\"=>{\"access_type\"=>\"offline\", \"approval_prompt\"=>\"\"}, \"name\"=>\"google_oauth2\"}\]$/)
           }
-        end 
+        end
         describe 'gitlab_git_http_server with hash value' do
           let(:params) {{:gitlab_git_http_server => {
             'enable' => true,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -21,23 +21,31 @@ describe 'gitlab', :type => :class do
 				case facts[:osfamily]
 				when 'Debian'
       		it { is_expected.to contain_apt__source('gitlab_official_ce') }
-				when 'redhat'
+				when 'RedHat'
       		it { is_expected.to contain_yumrepo('gitlab_official_ce') }
 				end
 
-				if facts[:gitlab_systemd] == "absent"
+				if ! facts[:gitlab_systemd]
 					it { is_expected.to contain_file('/etc/init.d/gitlab-runsvdir').with_ensure('link') }
+				else
+					it { is_expected.to contain_file('/etc/init.d/gitlab-runsvdir').with_ensure('absent') }
 				end
 			end
 
+			context "with custom facts" do
+
+			end
 			context "with class specific parameters" do
-				describe 'edition = ce' do
-      		let(:params) { {:edition => 'ce'} }
-      		it { is_expected.to contain_package('gitlab-ce').with_ensure('installed') }
-    		end
     		describe 'edition = ee' do
       		let(:params) { {:edition => 'ee'} }
       		it { is_expected.to contain_package('gitlab-ee').with_ensure('installed') }
+
+					case facts[:osfamily]
+					when 'Debian'
+      			it { is_expected.to contain_apt__source('gitlab_official_ee') }
+					when 'RedHat'
+      			it { is_expected.to contain_yumrepo('gitlab_official_ee') }
+					end
     		end
 			  describe 'external_url' do
       		let(:params) { {:external_url => 'http://gitlab.mycompany.com/'} }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,284 +1,187 @@
 require 'spec_helper'
 
-describe 'gitlab' do
-  context 'supported operating systems' do
-    describe "gitlab class without any parameters on Debian (Jessie)" do
-      let(:params) {{ }}
-      let(:facts) {{
-        :gitlab_systemd  => false,
-        :osfamily => 'debian',
-        :lsbdistid => 'debian',
-        :lsbdistcodename => 'jessie',
-        :operatingsystem => 'Debian',
-      }}
+describe 'gitlab', :type => :class do
+	on_supported_os.each do |os,facts|
+		context "on #{os}" do
+			let(:facts) do
+				facts
+			end
+			
+			context "with default params" do
+      	it { is_expected.to contain_class('gitlab::params') }
+      	it { is_expected.to contain_class('gitlab::install').that_comes_before('Class[gitlab::config]') }
+      	it { is_expected.to contain_class('gitlab::config') }
+      	it { is_expected.to contain_class('gitlab::service').that_subscribes_to('Class[gitlab::config]') }
+      	it { is_expected.to contain_exec('gitlab_reconfigure') }
+      	it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') }
+      	it { is_expected.to contain_service('gitlab-runsvdir') }
+      	it { is_expected.to contain_package('gitlab-ce').with_ensure('installed') }
+      	it { is_expected.to contain_class('gitlab') }
 
-      it { is_expected.to compile.with_all_deps }
+				case facts[:osfamily]
+				when 'Debian'
+      		it { is_expected.to contain_apt__source('gitlab_official_ce') }
+				when 'redhat'
+      		it { is_expected.to contain_yumrepo('gitlab_official_ce') }
+				end
 
-      it { is_expected.to contain_class('gitlab::params') }
-      it { is_expected.to contain_class('gitlab::install').that_comes_before('Class[gitlab::config]') }
-      it { is_expected.to contain_class('gitlab::config') }
-      it { is_expected.to contain_class('gitlab::service').that_subscribes_to('Class[gitlab::config]') }
-      it { is_expected.to contain_apt__source('gitlab_official_ce') }
-      it { is_expected.to contain_exec('gitlab_reconfigure') }
-      it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') }
+				if facts[:gitlab_systemd] == "absent"
+					it { is_expected.to contain_file('/etc/init.d/gitlab-runsvdir').with_ensure('link') }
+				end
+			end
 
-      it { is_expected.to contain_service('gitlab-runsvdir') }
-      it { is_expected.to contain_package('gitlab-ce').with_ensure('installed') }
-      it { is_expected.to contain_class('gitlab') }
+			context "with class specific parameters" do
+				describe 'edition = ce' do
+      		let(:params) { {:edition => 'ce'} }
+      		it { is_expected.to contain_package('gitlab-ce').with_ensure('installed') }
+    		end
+    		describe 'edition = ee' do
+      		let(:params) { {:edition => 'ee'} }
+      		it { is_expected.to contain_package('gitlab-ee').with_ensure('installed') }
+    		end
+			  describe 'external_url' do
+      		let(:params) { {:external_url => 'http://gitlab.mycompany.com/'} }
+      		it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') \
+        		.with_content(/^\s*external_url 'http:\/\/gitlab\.mycompany\.com\/'$/)
+      		}
+    		end
+    		describe 'external_port' do
+      		let(:params) { {:external_port => 987654} }
+      		it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') \
+        		.with_content(/^\s*external_port '987654'$/)
+      		}
+    		end
+    		describe 'nginx' do
+      		let(:params) { {:nginx => {
+        		'enable' => true,
+        		'listen_port' => 80,
+        		}
+      		}}
+      		it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') \
+        		.with_content(/^\s*nginx\['enable'\] = true$/)
+        		.with_content(/^\s*nginx\['listen_port'\] = ('|)80('|)$/)
+      		}
+    		end	
+				describe 'secrets' do
+      		let(:params) { {:secrets => {
+        		'gitlab_shell' => {
+          		'secret_token' => 'mysupersecrettoken1',
+        		},
+        		'gitlab_rails' => {
+          		'secret_token' => 'mysupersecrettoken2',
+        		},
+        		'gitlab_ci' => {
+          		'secret_token' => 'null',
+          		'secret_key_base' => 'mysupersecrettoken3',
+          		'db_key_base' => 'mysupersecrettoken4',
+        		},
+      		}}}
+      		it { is_expected.to contain_file('/etc/gitlab/gitlab-secrets.json') \
+        		.with_content(/{\n  \"gitlab_shell\": {\n    \"secret_token\": \"mysupersecrettoken1\"\n  },\n  \"gitlab_rails\": {\n    \"secret_token\": \"mysupersecrettoken2\"\n  },\n  \"gitlab_ci\": {\n    \"secret_token\": \"null\",\n    \"secret_key_base\": \"mysupersecrettoken3\",\n    \"db_key_base\": \"mysupersecrettoken4\"\n  }\n}\n/m)
+      		}
+    		end
+				describe 'gitlab_rails with hash value' do
+      		let(:params) { {:gitlab_rails => {
+        		'ldap_enabled' => true,
+        		'ldap_servers' => {
+          		'main' => {
+            		'label' => 'LDAP',
+            		'host' => '_your_ldap_server',
+            		'port' => 389,
+            		'uid' => 'sAMAccountName',
+            		'method' => 'plain',
+            		'bind_dn' => '_the_full_dn_of_the_user_you_will_bind_with',
+            		'password' => '_the_password_of_the_bind_user',
+            		'active_directory' => true,
+            		'allow_username_or_email_login' => false,
+            		'block_auto_created_users' => false,
+            		'base' => '',
+            		'user_filter' => '',
+          		}
+        		},
+        		'omniauth_providers' => [
+          		{
+            		'name' => 'google_oauth2',
+            		'app_id' => 'YOUR APP ID',
+            		'app_secret' => 'YOUR APP SECRET',
+            		'args' => { 'access_type' => 'offline', 'approval_prompt' => '' }
+          		}
+        		]
+      		}}}
+      		let(:expected_content){ {
+        		:gitlab_rb__ldap_servers => %Q{gitlab_rails['ldap_servers'] = {\"main\"=>{\"active_directory\"=>true, \"allow_username_or_email_login\"=>false, \"base\"=>\"\", \"bind_dn\"=>\"_the_full_dn_of_the_user_you_will_bind_with\", \"block_auto_created_users\"=>false, \"host\"=>\"_your_ldap_server\", \"label\"=>\"LDAP\", \"method\"=>\"plain\", \"password\"=>\"_the_password_of_the_bind_user\", \"port\"=>389, \"uid\"=>\"sAMAccountName\", \"user_filter\"=>\"\"}}\n}
+      		}}
+      		it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') \
+        		.with_content(/^\s*gitlab_rails\['ldap_enabled'\] = true$/)
+        		.with_content( /\s*#{Regexp.quote(expected_content[:gitlab_rb__ldap_servers])}/m )
+        		.with_content(/^\s*gitlab_rails\['omniauth_providers'\] = \[{\"app_id\"=>\"YOUR APP ID\", \"app_secret\"=>\"YOUR APP SECRET\", \"args\"=>{\"access_type\"=>\"offline\", \"approval_prompt\"=>\"\"}, \"name\"=>\"google_oauth2\"}\]$/)
+      		}
+    		end	
+				describe 'gitlab_git_http_server with hash value' do
+      		let(:params) {{:gitlab_git_http_server => {
+        		'enable' => true,
+      		}}}
+      		it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') \
+        		.with_content(/^\s*gitlab_git_http_server\['enable'\] = true$/)
+      		}
+    		end
+    		describe 'gitlab_rails with string value' do
+      		let(:params) {{:gitlab_rails => {
+        		'backup_path' => '/opt/gitlab_backup',
+      		}}}
+      		it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') \
+        		.with_content(/^\s*gitlab_rails\['backup_path'\] = "\/opt\/gitlab_backup"$/)
+      		}
+    		end
+    		describe 'rack_attack_git_basic_auth with Numbers and Strings' do
+      		let(:params) {{
+         		:gitlab_rails => {
+           		'rack_attack_git_basic_auth' => {
+             		'enable' => true,
+             		'ip_whitelist' => ["127.0.0.1", "10.0.0.0"],
+             		'maxretry' => 10,
+             		'findtime' => 60,
+             		'bantime' => 3600,
+           		},
+         		},
+       		}}
+       		it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') \
+         		.with_content(/^\s*gitlab_rails\['rack_attack_git_basic_auth'\] = {\"bantime\"=>3600, \"enable\"=>true, \"findtime\"=>60, \"ip_whitelist\"=>\[\"127.0.0.1\", \"10.0.0.0\"\], \"maxretry\"=>10}$/)
+       		}
+    		end
+    		describe 'mattermost external URL' do
+      		let(:params) {{:mattermost_external_url => 'https://mattermost.myserver.tld' }}
+      		it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') \
+        		.with_content(/^\s*mattermost_external_url 'https:\/\/mattermost\.myserver\.tld'$/)
+      		}
+    		end
+    		describe 'mattermost with hash value' do
+      		let(:params) {{:mattermost => {
+        		'enable' => true,
+      		}}}
+      		it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') \
+        		.with_content(/^\s*mattermost\['enable'\] = true$/)
+      		}
+    		end
+    		describe 'with manage_package => false' do
+      		let(:params) {{:manage_package => false }}
+      		it { should_not contain_package('gitlab-ce') }
+      		it { should_not contain_package('gitlab-ee') }
+    		end
+			end
+		end
+	end
+
+	context "on usupported os" do
+		let(:facts) {{
+    	:gitlab_systemd  => false,
+    	:osfamily        => 'Solaris',
+    	:operatingsystem => 'Nexenta',
+		}}
+
+		describe 'gitlab class without any parameters on Solaris/Nexenta' do
+      it { is_expected.to compile.and_raise_error(/is not supported/) }
     end
-    describe "gitlab class without any parameters on RedHat (CentOS)" do
-      let(:params) {{ }}
-      let(:facts) {{
-        :gitlab_systemd  => false,
-        :osfamily => 'redhat',
-        :operatingsystem => 'CentOS',
-        :operatingsystemmajrelease => '6',
-        :os              => {
-          :architecture => "x86_64",
-          :family => "RedHat",
-          :hardware => "x86_64",
-          :name => "CentOS",
-          :release => {
-            :full => "6.7",
-            :major => "6",
-            :minor => "7"
-          },
-          :selinux => {
-            :enabled => false
-          }
-        },
-      }}
+	end
 
-      it { is_expected.to compile.with_all_deps }
-
-      it { is_expected.to contain_class('gitlab::params') }
-      it { is_expected.to contain_class('gitlab::install').that_comes_before('Class[gitlab::config]') }
-      it { is_expected.to contain_class('gitlab::config') }
-      it { is_expected.to contain_class('gitlab::service').that_subscribes_to('Class[gitlab::config]') }
-      it { is_expected.to contain_yumrepo('gitlab_official_ce') }
-
-      it { is_expected.to contain_service('gitlab-runsvdir') }
-      it { is_expected.to contain_package('gitlab-ce').with_ensure('installed') }
-    end
-  end
-
-  context 'unsupported operating system' do
-    describe 'gitlab class without any parameters on Solaris/Nexenta' do
-      let(:facts) {{
-        :gitlab_systemd  => false,
-        :osfamily        => 'Solaris',
-        :operatingsystem => 'Nexenta',
-      }}
-
-      it { expect { is_expected.to contain_package('gitlab') }.to raise_error(Puppet::Error, /OS family Solaris not supported/) }
-    end
-  end
-
-  context 'linking init script on non-systemd' do
-    describe 'gitlab class on a non-systemd machine' do
-      let(:facts) {{
-        :gitlab_systemd => false,
-        :osfamily => 'redhat',
-        :operatingsystem => 'CentOS',
-        :operatingsystemmajrelease => '6',
-        :os              => {
-          :architecture => "x86_64",
-          :family => "RedHat",
-          :hardware => "x86_64",
-          :name => "CentOS",
-          :release => {
-            :full => "6.7",
-            :major => "6",
-            :minor => "7"
-          },
-          :selinux => {
-            :enabled => false
-          }
-        },
-      }}
-
-      it { is_expected.to contain_file('/etc/init.d/gitlab-runsvdir').with_ensure('link') }
-    end
-
-    describe 'gitlab class on a systemd machine' do
-      let(:facts) {{
-        :gitlab_systemd => true,
-        :osfamily => 'redhat',
-        :operatingsystem => 'CentOS',
-        :operatingsystemmajrelease => '6',
-        :os              => {
-          :architecture => "x86_64",
-          :family => "RedHat",
-          :hardware => "x86_64",
-          :name => "CentOS",
-          :release => {
-            :full => "7.2",
-            :major => "7",
-            :minor => "2"
-          },
-          :selinux => {
-            :enabled => false
-          }
-        },
-      }}
-
-      it { is_expected.to contain_file('/etc/init.d/gitlab-runsvdir').with_ensure('absent') }
-    end
-  end
-
-  context 'gitlab specific parameters' do
-    let(:facts) {{
-      :gitlab_systemd  => false,
-      :osfamily => 'debian',
-      :lsbdistid => 'debian',
-      :lsbdistcodename => 'jessie',
-      :operatingsystem => 'Debian',
-    }}
-
-    describe 'edition = ce' do
-      let(:params) { {:edition => 'ce'} }
-      it { is_expected.to contain_package('gitlab-ce').with_ensure('installed') }
-    end
-    describe 'edition = ee' do
-      let(:params) { {:edition => 'ee'} }
-      it { is_expected.to contain_package('gitlab-ee').with_ensure('installed') }
-    end
-    describe 'external_url' do
-      let(:params) { {:external_url => 'http://gitlab.mycompany.com/'} }
-      it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') \
-        .with_content(/^\s*external_url 'http:\/\/gitlab\.mycompany\.com\/'$/)
-      }
-    end
-    describe 'external_port' do
-      let(:params) { {:external_port => 987654} }
-      it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') \
-        .with_content(/^\s*external_port '987654'$/)
-      }
-    end
-    describe 'nginx' do
-      let(:params) { {:nginx => {
-        'enable' => true,
-        'listen_port' => 80,
-        }
-      }}
-      it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') \
-        .with_content(/^\s*nginx\['enable'\] = true$/)
-        .with_content(/^\s*nginx\['listen_port'\] = ('|)80('|)$/)
-      }
-    end
-    describe 'secrets' do
-      let(:params) { {:secrets => {
-        'gitlab_shell' => {
-          'secret_token' => 'mysupersecrettoken1',
-        },
-        'gitlab_rails' => {
-          'secret_token' => 'mysupersecrettoken2',
-        },
-        'gitlab_ci' => {
-          'secret_token' => 'null',
-          'secret_key_base' => 'mysupersecrettoken3',
-          'db_key_base' => 'mysupersecrettoken4',
-        },
-      }}}
-      it { is_expected.to contain_file('/etc/gitlab/gitlab-secrets.json') \
-        .with_content(/{\n  \"gitlab_shell\": {\n    \"secret_token\": \"mysupersecrettoken1\"\n  },\n  \"gitlab_rails\": {\n    \"secret_token\": \"mysupersecrettoken2\"\n  },\n  \"gitlab_ci\": {\n    \"secret_token\": \"null\",\n    \"secret_key_base\": \"mysupersecrettoken3\",\n    \"db_key_base\": \"mysupersecrettoken4\"\n  }\n}\n/m)
-      }
-    end
-    describe 'gitlab_rails with hash value' do
-      let(:params) { {:gitlab_rails => {
-        'ldap_enabled' => true,
-        'ldap_servers' => {
-          'main' => {
-            'label' => 'LDAP',
-            'host' => '_your_ldap_server',
-            'port' => 389,
-            'uid' => 'sAMAccountName',
-            'method' => 'plain',
-            'bind_dn' => '_the_full_dn_of_the_user_you_will_bind_with',
-            'password' => '_the_password_of_the_bind_user',
-            'active_directory' => true,
-            'allow_username_or_email_login' => false,
-            'block_auto_created_users' => false,
-            'base' => '',
-            'user_filter' => '',
-          }
-        },
-        'omniauth_providers' => [
-          {
-            'name' => 'google_oauth2',
-            'app_id' => 'YOUR APP ID',
-            'app_secret' => 'YOUR APP SECRET',
-            'args' => { 'access_type' => 'offline', 'approval_prompt' => '' }
-          }
-        ]
-      }}}
-
-      let(:expected_content){ {
-        :gitlab_rb__ldap_servers => %Q{gitlab_rails['ldap_servers'] = {\"main\"=>{\"active_directory\"=>true, \"allow_username_or_email_login\"=>false, \"base\"=>\"\", \"bind_dn\"=>\"_the_full_dn_of_the_user_you_will_bind_with\", \"block_auto_created_users\"=>false, \"host\"=>\"_your_ldap_server\", \"label\"=>\"LDAP\", \"method\"=>\"plain\", \"password\"=>\"_the_password_of_the_bind_user\", \"port\"=>389, \"uid\"=>\"sAMAccountName\", \"user_filter\"=>\"\"}}\n}
-      }}
-
-      it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') \
-        .with_content(/^\s*gitlab_rails\['ldap_enabled'\] = true$/)
-        .with_content( /\s*#{Regexp.quote(expected_content[:gitlab_rb__ldap_servers])}/m )
-        .with_content(/^\s*gitlab_rails\['omniauth_providers'\] = \[{\"app_id\"=>\"YOUR APP ID\", \"app_secret\"=>\"YOUR APP SECRET\", \"args\"=>{\"access_type\"=>\"offline\", \"approval_prompt\"=>\"\"}, \"name\"=>\"google_oauth2\"}\]$/)
-      }
-    end
-    describe 'gitlab_git_http_server with hash value' do
-      let(:params) {{:gitlab_git_http_server => {
-        'enable' => true,
-      }}}
-
-      it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') \
-        .with_content(/^\s*gitlab_git_http_server\['enable'\] = true$/)
-      }
-    end
-    describe 'gitlab_rails with string value' do
-      let(:params) {{:gitlab_rails => {
-        'backup_path' => '/opt/gitlab_backup',
-      }}}
-
-      it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') \
-        .with_content(/^\s*gitlab_rails\['backup_path'\] = "\/opt\/gitlab_backup"$/)
-      }
-    end
-    describe 'rack_attack_git_basic_auth with Numbers and Strings' do
-      let(:params) {{
-         :gitlab_rails => {
-           'rack_attack_git_basic_auth' => {
-             'enable' => true,
-             'ip_whitelist' => ["127.0.0.1", "10.0.0.0"],
-             'maxretry' => 10,
-             'findtime' => 60,
-             'bantime' => 3600,
-           },
-         },
-       }}
-
-       it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') \
-         .with_content(/^\s*gitlab_rails\['rack_attack_git_basic_auth'\] = {\"bantime\"=>3600, \"enable\"=>true, \"findtime\"=>60, \"ip_whitelist\"=>\[\"127.0.0.1\", \"10.0.0.0\"\], \"maxretry\"=>10}$/)
-       }
-    end
-    describe 'mattermost external URL' do
-      let(:params) {{:mattermost_external_url => 'https://mattermost.myserver.tld' }}
-
-      it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') \
-        .with_content(/^\s*mattermost_external_url 'https:\/\/mattermost\.myserver\.tld'$/)
-      }
-    end
-    describe 'mattermost with hash value' do
-      let(:params) {{:mattermost => {
-        'enable' => true,
-      }}}
-
-      it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') \
-        .with_content(/^\s*mattermost\['enable'\] = true$/)
-      }
-    end
-    describe 'with manage_package => false' do
-      let(:params) {{:manage_package => false }}
-
-      it { should_not contain_package('gitlab-ce') }
-      it { should_not contain_package('gitlab-ee') }
-    end
-  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,6 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
+require 'rspec-puppet-facts'
+include RspecPuppetFacts
 
 RSpec.configure do |c|
   c.hiera_config = File.expand_path(File.join(__FILE__, '../fixtures/hiera.yaml'))


### PR DESCRIPTION
I was preparing to make a merge request for a new feature, and found that I couldn't really add a spec to it for both `deb` and `rpm` without duplicating about 20 LOC in the `spec/classes/init_spec.rb` file.

I used one of the more useful features of the [rspec-puppet-facts](https://github.com/mcanevet/rspec-puppet-facts) gem, to beef up the quality of the tests, and refactored the design to allow new features to be added while typically only requiring 4 new lines of code to test the feature across _all_ supported operating systems.

The overall goal of this PR is to allow us to more easily add new specs by increasing the flexibility of the testing utilities, while simultaneously increasing the likelihood we'll catch a bug for a supported os before it's tagged to a release.

This PR is quite large, so here's a few bullets to help navigate it:

- I reduced the Lines of Code by nearly 30%
- increased coverage (`67%` -> `72%`)
- increased number of tests executed (`54` -> `319`)
- improved code quality by running each test against _all_ supported operating systems. (most tests previously only ran against debian)
- instead of declaring a fact hash with alternative OS/architecture for a context, we can now just use a simple evaluation (if/unless/case) on an individual fact to do something like testing `apt` vs `yum`. (see code for this example)
- changed the unsupported test:

```
- it { expect { is_expected.to contain_package('gitlab') }.to raise_error(Puppet::Error, /OS family Solaris not supported/) }
+ it { is_expected.to compile.and_raise_error(/is not supported/) }
```