### PR TITLE
fix manage_accounts => false error

### DIFF
--- a/templates/gitlab.rb.erb
+++ b/templates/gitlab.rb.erb
@@ -418,7 +418,12 @@ registry_nginx['<%= k -%>'] = <%= decorate(@_real_registry_nginx[k]) %>
 
 <%- @manage_accounts.keys.sort.each do |k| -%>
 manage_accounts['<%= k -%>'] = <%= decorate(@manage_accounts[k]) %>
-<%- end end -%>
+<%- end -%> 
+<%- else -%> 
+manage_accounts['enable'] = false 
+<%- end -%>
+
+
 <%- if @redis_sentinel_role -%>
 
 ##################


### PR DESCRIPTION
without the line:

manage_accounts['enable'] = false

in gitlab.rb, the chef subcalls do not respect the gitlab class parameter of manage_accounts => false 
