### PR TITLE
add support for chained global hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,26 @@ gitlab::custom_hooks:
     source: 'puppet:///modules/my_module/post-receive'
 ```
 
+Since GitLab Shell 4.1.0 and GitLab 8.15 Chained hooks are supported. You can
+create global hooks which will run for each repository on your server. Global
+hooks can be created as a pre-receive, post-receive, or update hook. 
+
+```puppet
+gitlab::global_hook { 'my_custom_hook':
+  type            => 'post-receive',
+  source          => 'puppet:///modules/my_module/post-receive',
+}
+```
+
+or via hiera
+
+```yaml
+gitlab::global_hooks:
+  my_custom_hook:
+    type: post-receive
+    source: 'puppet:///modules/my_module/post-receive'
+```
+
 ### Gitlab CI Runner Limitations
 
 The Gitlab CI runner installation is at the moment only tested on Ubuntu 14.04.

--- a/manifests/global_hook.pp
+++ b/manifests/global_hook.pp
@@ -1,0 +1,104 @@
+# == Define: gitlab::global_hook
+#
+# Manage global chain loaded hook files for all GitLab projects. Hooks can be created
+# as a pre-receive, post-receive, or update hook. It's possible to create
+# multipe hooks per type as long as their names are unique.
+#
+# Support for chained (global) hooks is introduced in GitLab Shell 4.1.0 and GitLab 8.15.
+#
+# === Parameters
+#
+# [*namevar*]
+#   The namevar is used as chail file name and should be unique. Supply a descriptive
+#   namevar of your choosing.
+#
+# [*type*]
+#   The custom hook type. Should be one of pre-receive, post-receive, or update.
+#
+# [*content*]
+#   Specify the custom hook contents either as a string or using the template
+#   function. If this paramter is specified source parameter must not be
+#   present.
+#
+# [*source*]
+#   Specify a file source path to populate the custom hook contents. If this
+#   paramter is specified content parameter must not be present.
+#
+# [*custom_hooks_dir*]
+#   The GitLab shell repos path. This defaults to
+#   '/opt/gitlab/embedded/service/gitlab-shell/hooks' if not present.
+#
+# [*git_username*]
+#   The git user name. Defaults to 'git' if not present.
+#
+# [*git_groupname*]
+#   The git group name. Defaults to 'git' if not present.
+#
+#
+# === Examples
+#
+#   gitlab::custom_hook { 'my_custom_hook':
+#     type            => 'post-receive',
+#     source          => 'puppet:///modules/my_module/post-receive',
+#   }
+#
+# === Authors
+# Hidde Boomsma <hboomsma@hostnet.nl>
+#
+# Inspired by the custom_hook module by:
+# Drew A. Blessing <drew.blessing@mac.com>
+#
+# === Copyright
+#
+# Copyright 2017 Hidde Boomsma
+#
+define gitlab::global_hook(
+  $type = undef,
+  $content = undef,
+  $source = undef,
+  $custom_hooks_dir = undef
+) {
+  validate_re($type, '^(post-receive|pre-receive|update)$')
+
+  if $custom_hooks_dir {
+    $_custom_hooks_dir = $custom_hooks_dir
+  } elsif $::gitlab::custom_hooks_dir {
+    $_custom_hooks_dir = $::gitlab::custom_hooks_dir
+  } else {
+    $_custom_hooks_dir = '/opt/gitlab/embedded/service/gitlab-shell/hooks'
+  }
+  validate_absolute_path($_custom_hooks_dir)
+
+  if ! ($content) and ! ($source) {
+    fail('gitlab::custom_hook resource must specify either content or source')
+  }
+
+  if ($content) and ($source) {
+    fail('gitlab::custom_hook resource must specify either content or source, but not both')
+  }
+
+  if $source {
+    validate_re($source, '^puppet:')
+  }
+
+  $hook_path = "${_custom_hooks_dir}/${type}.d"
+
+  File {
+    owner => $::gitlab::service_user,
+    group => $::gitlab::service_group,
+    mode  => '0755',
+  }
+
+  # Create the hook chain directory for this project, if it doesn't exist
+  if !defined(File[$hook_path]) {
+    file { $hook_path:
+      ensure => directory,
+    }
+  }
+
+  file { "${hook_path}/${name}":
+    ensure  => 'present',
+    content => $content,
+    source  => $source,
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -333,6 +333,7 @@ class gitlab (
   $ci_unicorn = undef,
   $config_manage = $::gitlab::params::config_manage,
   $config_file = $::gitlab::params::config_file,
+  $custom_hooks_dir = undef,
   $external_url = $::gitlab::params::external_url,
   $external_port = undef,
   $geo_postgresql = undef,
@@ -388,6 +389,7 @@ class gitlab (
   $user = undef,
   $web_server = undef,
   $custom_hooks = {},
+  $global_hooks = {},
 ) inherits ::gitlab::params {
 
   # package installation handling
@@ -404,6 +406,7 @@ class gitlab (
   validate_re($edition, [ '^ee$', '^ce$' ])
   validate_bool($config_manage)
   validate_absolute_path($config_file)
+  if $custom_hooks_dir { validate_absolute_path($custom_hooks_dir) }
   if $geo_postgresql { validate_hash($geo_postgresql) }
   validate_bool($geo_primary_role)
   if $geo_secondary { validate_hash($geo_secondary) }
@@ -452,6 +455,7 @@ class gitlab (
   if $high_availability { validate_hash($high_availability) }
   if $manage_accounts { validate_hash($manage_accounts) }
   validate_hash($custom_hooks)
+  validate_hash($glocal_hooks)
 
   class { '::gitlab::install': } ->
   class { '::gitlab::config': } ~>
@@ -462,5 +466,5 @@ class gitlab (
   contain gitlab::service
 
   create_resources(gitlab::custom_hook, $custom_hooks)
-
+  create_resources(gitlab::global_hook, $global_hooks)
 }


### PR DESCRIPTION
> Introduced in GitLab Shell 4.1.0 and GitLab 8.15.
> 
> Hooks can be also placed in hooks/<hook_name>.d (global).