### PR TITLE
Update package name for >= v10.0 release of Gitlab

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v2.0.0 ?
+
+WARNING: Since Gitlab 10.0 gitlab-ci-multi-runner project has been renamed to gitlab-runner
+
+* Change package to new `gitlab-runner` >= 10.0
+
 ## v1.15.1 [2017-07-28]
 
 * Dummy release for Puppet Forge

--- a/manifests/cirunner.pp
+++ b/manifests/cirunner.pp
@@ -12,7 +12,7 @@
 # [*hiera_default_config_key*]
 #   Default: gitlab_ci_runners_defaults
 #   Name of hiera hash with default configs for CI Runners.
-#   The config is the parameters for the /usr/bin/gitlab-ci-multi-runner register
+#   The config is the parameters for the /usr/bin/gitlab-runner register
 #   command.
 #
 # [*hiera_runners_key*]
@@ -50,7 +50,7 @@ class gitlab::cirunner (
   if $manage_docker {
     include ::docker
     # workaround for cirunner issue #1617
-    # https://gitlab.com/gitlab-org/gitlab-ci-multi-runner/issues/1617
+    # https://gitlab.com/gitlab-org/gitlab-runner/issues/1617
     ensure_packages($xz_package_name)
 
     $docker_images = {
@@ -74,7 +74,7 @@ class gitlab::cirunner (
 
         ::apt::source { 'apt_gitlabci':
           comment  => 'GitlabCI Runner Repo',
-          location => "https://packages.gitlab.com/runner/gitlab-ci-multi-runner/${distid}/",
+          location => "https://packages.gitlab.com/runner/gitlab-runner/${distid}/",
           release  => $::lsbdistcodename,
           repos    => 'main',
           key      => {
@@ -86,14 +86,14 @@ class gitlab::cirunner (
             'deb' => true,
           }
         }
-        Apt::Source['apt_gitlabci'] -> Package['gitlab-ci-multi-runner']
-        Exec['apt_update'] -> Package['gitlab-ci-multi-runner']
+        Apt::Source['apt_gitlabci'] -> Package['gitlab-runner']
+        Exec['apt_update'] -> Package['gitlab-runner']
       }
       'RedHat': {
-        yumrepo { 'runner_gitlab-ci-multi-runner':
+        yumrepo { 'runner_gitlab-runner':
           ensure        => 'present',
-          baseurl       => "https://packages.gitlab.com/runner/gitlab-ci-multi-runner/el/${::operatingsystemmajrelease}/\$basearch",
-          descr         => 'runner_gitlab-ci-multi-runner',
+          baseurl       => "https://packages.gitlab.com/runner/gitlab-runner/el/${::operatingsystemmajrelease}/\$basearch",
+          descr         => 'runner_gitlab-runner',
           enabled       => '1',
           gpgcheck      => '0',
           gpgkey        => 'https://packages.gitlab.com/gpg.key',
@@ -102,10 +102,10 @@ class gitlab::cirunner (
           sslverify     => '1',
         }
 
-        yumrepo { 'runner_gitlab-ci-multi-runner-source':
+        yumrepo { 'runner_gitlab-runner-source':
           ensure        => 'present',
-          baseurl       => "https://packages.gitlab.com/runner/gitlab-ci-multi-runner/el/${::operatingsystemmajrelease}/SRPMS",
-          descr         => 'runner_gitlab-ci-multi-runner-source',
+          baseurl       => "https://packages.gitlab.com/runner/gitlab-runner/el/${::operatingsystemmajrelease}/SRPMS",
+          descr         => 'runner_gitlab-runner-source',
           enabled       => '1',
           gpgcheck      => '0',
           gpgkey        => 'https://packages.gitlab.com/gpg.key',
@@ -120,7 +120,7 @@ class gitlab::cirunner (
     }
   }
 
-  package { 'gitlab-ci-multi-runner':
+  package { 'gitlab-runner':
     ensure => $package_ensure,
   }
 
@@ -131,15 +131,15 @@ class gitlab::cirunner (
       path    => '/etc/gitlab-runner/config.toml',
       line    => "concurrent = ${concurrent}",
       match   => '^concurrent = \d+',
-      require => Package['gitlab-ci-multi-runner'],
+      require => Package['gitlab-runner'],
       notify  => Exec['gitlab-runner-restart'],
     }
   }
 
   exec { 'gitlab-runner-restart':
-    command     => '/usr/bin/gitlab-ci-multi-runner restart',
+    command     => '/usr/bin/gitlab-runner restart',
     refreshonly => true,
-    require     => Package['gitlab-ci-multi-runner'],
+    require     => Package['gitlab-runner'],
   }
 
   $runners_hash = hiera_hash($hiera_runners_key, {})

--- a/manifests/runner.pp
+++ b/manifests/runner.pp
@@ -48,7 +48,7 @@ define gitlab::runner (
 
   # Execute gitlab ci multirunner register
   exec {"Register_runner_${title}":
-    command => "/usr/bin/gitlab-ci-multi-runner register -n ${parameters_string}",
+    command => "/usr/bin/gitlab-runner register -n ${parameters_string}",
     unless  => "/bin/grep ${runner_name} ${toml_file}",
   }
 

--- a/spec/acceptance/gitlabci_spec.rb
+++ b/spec/acceptance/gitlabci_spec.rb
@@ -14,7 +14,7 @@ describe 'gitlab:;cirunner class' do
       apply_manifest(pp, :catch_changes  => true)
     end
 
-    describe package('gitlab-ci-multi-runner') do
+    describe package('gitlab-runner') do
       it { is_expected.to be_installed }
     end
   end

--- a/spec/acceptance/travis_ci_acceptance_spec.rb
+++ b/spec/acceptance/travis_ci_acceptance_spec.rb
@@ -68,7 +68,7 @@ describe 'gitlab class' do
       apply_manifest(pp, :catch_changes  => true)
     end
 
-    describe package('gitlab-ci-multi-runner') do
+    describe package('gitlab-runner') do
       it { is_expected.to be_installed }
     end
   end

--- a/spec/classes/cirunner_spec.rb
+++ b/spec/classes/cirunner_spec.rb
@@ -19,7 +19,7 @@ describe 'gitlab::cirunner' do
       it { is_expected.to contain_class('docker::images') }
       it { is_expected.to contain_apt__source('apt_gitlabci') }
 
-      it { is_expected.to contain_package('gitlab-ci-multi-runner').with_ensure('installed') }
+      it { is_expected.to contain_package('gitlab-runner').with_ensure('installed') }
     end
     describe "gitlab::cirunner class without any parameters on RedHat (CentOS)" do
       let(:params) {{ }}
@@ -52,9 +52,9 @@ describe 'gitlab::cirunner' do
 
       it { is_expected.to contain_class('docker') }
       it { is_expected.to contain_class('docker::images') }
-      it { is_expected.to contain_yumrepo('runner_gitlab-ci-multi-runner').with_baseurl('https://packages.gitlab.com/runner/gitlab-ci-multi-runner/el/6/$basearch') }
+      it { is_expected.to contain_yumrepo('runner_gitlab-runner').with_baseurl('https://packages.gitlab.com/runner/gitlab-runner/el/6/$basearch') }
 
-      it { is_expected.to contain_package('gitlab-ci-multi-runner').with_ensure('installed') }
+      it { is_expected.to contain_package('gitlab-runner').with_ensure('installed') }
     end
     describe "gitlab::cirunner class OS-independent behavior" do
       let(:facts) {{
@@ -83,10 +83,10 @@ describe 'gitlab::cirunner' do
       }}
 
       context 'with default parameters' do
-        it { should contain_exec('gitlab-runner-restart').that_requires('Package[gitlab-ci-multi-runner]') }
+        it { should contain_exec('gitlab-runner-restart').that_requires('Package[gitlab-runner]') }
         it do
           should contain_exec('gitlab-runner-restart').with({
-            'command'     => '/usr/bin/gitlab-ci-multi-runner restart',
+            'command'     => '/usr/bin/gitlab-runner restart',
             'refreshonly' => true,
           })
         end
@@ -96,7 +96,7 @@ describe 'gitlab::cirunner' do
 
       context 'with concurrent => 10' do
         let(:params) { { :concurrent => 10 } }
-        it { should contain_file_line('gitlab-runner-concurrent').that_requires('Package[gitlab-ci-multi-runner]') }
+        it { should contain_file_line('gitlab-runner-concurrent').that_requires('Package[gitlab-runner]') }
         it { should contain_file_line('gitlab-runner-concurrent').that_notifies('Exec[gitlab-runner-restart]') }
         it do
           should contain_file_line('gitlab-runner-concurrent').with({


### PR DESCRIPTION
Since 10.0 release of Gitlab the binary (and packages names) for gitlab runner has changed from `gitlab-ci-multi-runner` to `gitlab-runner`. See https://gitlab.com/gitlab-org/gitlab-runner/blob/v10.0.0/CHANGELOG.md

This merge requests take this into account.

As this is a big breaking change I recommend to bump the major version of this module.

WDYT?