### PR TITLE
Fix for new git_data_dirs syntax in Gitlab 10

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -20,7 +20,7 @@ class gitlab::config {
   $git_data_dir = $::gitlab::git_data_dir
   # git_data_dirs is the new way to specify data_dirs, introduced in 8.10
   if $git_data_dir {
-    $git_data_dirs = merge({ 'default' => $::gitlab::git_data_dir }, $::gitlab::git_data_dirs)
+    $git_data_dirs = merge({ 'default' => { 'path' => $::gitlab::git_data_dir} }, $::gitlab::git_data_dirs)
   } else {
     $git_data_dirs = $::gitlab::git_data_dirs
   }


### PR DESCRIPTION
Gitlab 10 changes the syntax of the git_data_dirs parameter. If you do not specify git_data_dirs, and only supply git_data_dir, it will put a deprecated syntax in, triggering a warning.

This fixes the syntax. 

Is this ok to merge as is, or does it need some logic to determine if the version specified is <10? 

This fixes #162 