### PR TITLE
Add support for metrics_server in CI Runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ classes:
 
 gitlab::cirunner::concurrent: 4
 
+gitlab::cirunner::metrics_server: "localhost:8888"
+
 gitlab_ci_runners:
   test_runner1:{}
   test_runner2:{}

--- a/manifests/cirunner.pp
+++ b/manifests/cirunner.pp
@@ -9,6 +9,11 @@
 #   The limit on the number of jobs that can run concurrently among
 #   all runners, or `undef` to leave unmanaged.
 #
+# [*metrics_server*]
+#   Default: `undef`
+#   [host]:<port> to enable metrics server as described in
+#   https://docs.gitlab.com/runner/monitoring/README.html#configuration-of-the-metrics-http-server
+#
 # [*hiera_default_config_key*]
 #   Default: gitlab_ci_runners_defaults
 #   Name of hiera hash with default configs for CI Runners.
@@ -30,6 +35,7 @@
 #
 class gitlab::cirunner (
   $concurrent = undef,
+  $metrics_server = undef,
   $hiera_default_config_key = 'gitlab_ci_runners_defaults',
   $hiera_runners_key = 'gitlab_ci_runners',
   $manage_docker = true,
@@ -137,6 +143,18 @@ class gitlab::cirunner (
       path    => '/etc/gitlab-runner/config.toml',
       line    => "concurrent = ${concurrent}",
       match   => '^concurrent = \d+',
+      require => Package[$package_name],
+      notify  => Exec['gitlab-runner-restart'],
+    }
+  }
+
+  if $metrics_server {
+    validate_re($metrics_server, '.*:.+', 'metrics_server must be in the format [host]:<port>')
+
+    file_line { 'gitlab-runner-metrics-server':
+      path    => '/etc/gitlab-runner/config.toml',
+      line    => "metrics_server = \"${metrics_server}\"",
+      match   => '^metrics_server = .+',
       require => Package[$package_name],
       notify  => Exec['gitlab-runner-restart'],
     }

--- a/manifests/cirunner.pp
+++ b/manifests/cirunner.pp
@@ -42,7 +42,7 @@ class gitlab::cirunner (
   $manage_repo = true,
   $xz_package_name = 'xz-utils',
   $package_ensure = installed,
-  $package_name = 'gitlab-ci-multi-runner',
+  $package_name = 'gitlab-runner',
 ) {
 
   validate_string($hiera_default_config_key)

--- a/spec/acceptance/gitlabci_spec.rb
+++ b/spec/acceptance/gitlabci_spec.rb
@@ -14,7 +14,7 @@ describe 'gitlab:;cirunner class' do
       apply_manifest(pp, :catch_changes  => true)
     end
 
-    describe package('gitlab-ci-multi-runner') do
+    describe package('gitlab-runner') do
       it { is_expected.to be_installed }
     end
   end

--- a/spec/acceptance/travis_ci_acceptance_spec.rb
+++ b/spec/acceptance/travis_ci_acceptance_spec.rb
@@ -68,7 +68,7 @@ describe 'gitlab class' do
       apply_manifest(pp, :catch_changes  => true)
     end
 
-    describe package('gitlab-ci-multi-runner') do
+    describe package('gitlab-runner') do
       it { is_expected.to be_installed }
     end
   end

--- a/spec/classes/cirunner_spec.rb
+++ b/spec/classes/cirunner_spec.rb
@@ -110,14 +110,14 @@ describe 'gitlab::cirunner' do
         end
       end
 
-      context 'with metrics_server => localhost:8888' do
-        let(:params) { { :metrics_server => 'localhost:8888' } }
+      context 'with metrics_server => localhost:9252' do
+        let(:params) { { :metrics_server => 'localhost:9252' } }
         it { should contain_file_line('gitlab-runner-metrics-server').that_requires("Package[#{package_name}]") }
         it { should contain_file_line('gitlab-runner-metrics-server').that_notifies('Exec[gitlab-runner-restart]') }
         it do
           should contain_file_line('gitlab-runner-metrics-server').with({
             'path'  => '/etc/gitlab-runner/config.toml',
-            'line'  => 'metrics_server = "localhost:8888"',
+            'line'  => 'metrics_server = "localhost:9252"',
 	    'match' => '^metrics_server = .+',
           })
         end

--- a/spec/classes/cirunner_spec.rb
+++ b/spec/classes/cirunner_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'gitlab::cirunner' do
   context 'supported operating systems' do
-    package_name = 'gitlab-ci-multi-runner'
+    package_name = 'gitlab-runner'
 
     describe "gitlab::cirunner class without any parameters on Ubuntu Trusty" do
       let(:params) {{ }}

--- a/spec/classes/cirunner_spec.rb
+++ b/spec/classes/cirunner_spec.rb
@@ -117,7 +117,7 @@ describe 'gitlab::cirunner' do
         it do
           should contain_file_line('gitlab-runner-metrics-server').with({
             'path'  => '/etc/gitlab-runner/config.toml',
-            'line'  => 'metrics_server = localhost:8888',
+            'line'  => 'metrics_server = "localhost:8888"',
 	    'match' => '^metrics_server = .+',
           })
         end

--- a/spec/classes/cirunner_spec.rb
+++ b/spec/classes/cirunner_spec.rb
@@ -94,6 +94,7 @@ describe 'gitlab::cirunner' do
         end
         it { should contain_gitlab__runner('test_runner').that_requires('Exec[gitlab-runner-restart]') }
         it { should_not contain_file_line('gitlab-runner-concurrent') }
+        it { should_not contain_file_line('gitlab-runner-metrics-server') }
       end
 
       context 'with concurrent => 10' do
@@ -105,6 +106,19 @@ describe 'gitlab::cirunner' do
             'path'  => '/etc/gitlab-runner/config.toml',
             'line'  => 'concurrent = 10',
             'match' => '^concurrent = \d+',
+          })
+        end
+      end
+
+      context 'with metrics_server => localhost:8888' do
+        let(:params) { { :metrics_server => 'localhost:8888' } }
+        it { should contain_file_line('gitlab-runner-metrics-server').that_requires("Package[#{package_name}]") }
+        it { should contain_file_line('gitlab-runner-metrics-server').that_notifies('Exec[gitlab-runner-restart]') }
+        it do
+          should contain_file_line('gitlab-runner-metrics-server').with({
+            'path'  => '/etc/gitlab-runner/config.toml',
+            'line'  => 'metrics_server = localhost:8888',
+	    'match' => '^metrics_server = .+',
           })
         end
       end


### PR DESCRIPTION
Add support for setting the `metrics_server` parameter in CI Runner. Also installs a newer version of the runner from the proper repo (can be overridden). Closes #166 