### PR TITLE
apt dep version bump

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">=2.1.0 <3.0.0"
+      "version_requirement": ">=2.1.0 <5.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Apt changelog says it's fully backwards compatible. Figure just try a new version number in tests. And it appears the 3.x was skipped altogether. 