### PR TITLE
Fix repo URL for RHEL 7.  Enable gpgcheck and add in gitlab-ee key.

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -58,7 +58,7 @@ class gitlab::install {
 
         yumrepo { "gitlab_official_${edition}":
           descr         => 'Official repository for Gitlab',
-          baseurl       => "https://packages.gitlab.com/gitlab/gitlab-${edition}/el/${::os_version_major}/\$basearch",
+          baseurl       => "https://packages.gitlab.com/gitlab/gitlab-${edition}/el/${::operatingsystemmajrelease}/\$basearch",
           enabled       => 1,
           repo_gpgcheck => 1,
           gpgcheck      => 1,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -51,13 +51,18 @@ class gitlab::install {
       }
       'redhat': {
 
+        $gpgkey = $edition ? {
+            'ee'    => 'https://packages.gitlab.com/gitlab/gitlab-ee/gpgkey/gitlab-gitlab-ee-3D645A26AB9FBD22.pub.gpg',
+            default => 'https://packages.gitlab.com/gpg.key',
+        }
+
         yumrepo { "gitlab_official_${edition}":
           descr         => 'Official repository for Gitlab',
-          baseurl       => "https://packages.gitlab.com/gitlab/gitlab-${edition}/el/\$releasever/\$basearch",
+          baseurl       => "https://packages.gitlab.com/gitlab/gitlab-${edition}/el/${::os_version_major}/\$basearch",
           enabled       => 1,
-          gpgcheck      => 0,
-          gpgkey        => 'https://packages.gitlab.com/gpg.key',
           repo_gpgcheck => 1,
+          gpgcheck      => 1,
+          gpgkey        => $gpgkey,
           sslcacert     => '/etc/pki/tls/certs/ca-bundle.crt',
           sslverify     => 1,
         }


### PR DESCRIPTION
The yum variable $releasever is '7' in centos, but '7Server' in RHEL.

Also adding the proper GPG based on the edition installed (CE is signed by a different key than EE).  I am not sure if there is a better or more canonical place for their GPG key(s)